### PR TITLE
chore: more type stability, setup pyright as alternative option to mypy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: pipx run check-manifest
+  pyright:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - run: uv sync
+      - run: uv run pyright
 
   test:
     name: ${{ matrix.platform }} py${{ matrix.python-version }}
@@ -39,7 +51,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install the project
-        run: uv sync --all-extras --dev
+        run: uv sync
 
       - uses: pyvista/setup-headless-display-action@v3
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,10 +72,12 @@ repos:
   # as an alternative to that annoying list of packages,
   # pyright can use a virtual environment to find the installed packages
   # here we direct it to look in the current directory for a .venv folder
+  # however, this won't work for pre-commit.ci (because of environment creation limits)
+  # so we use stages: [manual], and run it manually in ci.yml
   - repo: https://github.com/RobertCraigie/pyright-python
     rev: v1.1.392.post0
     hooks:
       - id: pyright
         files: "^src/"
         args: [--venvpath, "."]
-        # stages: [manual]
+        stages: [manual]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,8 +20,8 @@ repos:
     hooks:
       - id: markdownlint
         args: [
-          --disable=MD033, # no-inline-html
-        ]
+            --disable=MD033, # no-inline-html
+          ]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.9.2
@@ -68,3 +68,14 @@ repos:
           - types-Pygments
           - types-PyYAML
           - zarr<3.0
+
+  # as an alternative to that annoying list of packages,
+  # pyright can use a virtual environment to find the installed packages
+  # here we direct it to look in the current directory for a .venv folder
+  - repo: https://github.com/RobertCraigie/pyright-python
+    rev: v1.1.392.post0
+    hooks:
+      - id: pyright
+        files: "^src/"
+        args: [--venvpath, "."]
+        # stages: [manual]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ dev = [
     "pre-commit>=4.0.1",
     "pyautogui>=0.9.54",
     "pyinstaller>=6.11.1",
+    "pyright>=1.1.392.post0",
     "pytest>=8.3.4",
     "pytest-cov>=6.0.0",
     "pytest-qt>=4.4.0",
@@ -121,7 +122,7 @@ skip-magic-trailing-comma = false # default is false
 
 # https://mypy.readthedocs.io/en/stable/config_file.html
 [tool.mypy]
-files = "src/**/"
+files = "src/**/*.py"
 strict = true
 disallow_any_generics = false
 disallow_subclassing_any = false
@@ -132,6 +133,13 @@ plugins = ["pydantic.mypy"]
 [[tool.mypy.overrides]]
 module = ["qtconsole.*", "pydevd.*"]
 ignore_missing_imports = true
+
+[tool.pyright]
+include = ["src"]
+pythonVersion = "3.10"
+enableExperimentalFeatures = true
+verboseOutput = true
+venv = ".venv"
 
 # https://docs.pytest.org/
 [tool.pytest.ini_options]

--- a/src/pymmcore_gui/_app.py
+++ b/src/pymmcore_gui/_app.py
@@ -8,7 +8,7 @@ import sys
 import traceback
 from contextlib import suppress
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from PyQt6.QtCore import pyqtSignal
 from PyQt6.QtGui import QIcon
@@ -98,7 +98,7 @@ def main() -> None:
     win.show()
 
     if "_PYI_SPLASH_IPC" in os.environ and importlib.util.find_spec("pyi_splash"):
-        import pyi_splash
+        import pyi_splash  # pyright: ignore [reportMissingModuleSource]
 
         pyi_splash.update_text("UI Loaded ...")
         pyi_splash.close()
@@ -177,9 +177,12 @@ def ndv_excepthook(
         with suppress(Exception):
             import threading
 
-            import pydevd
+            import pydevd  # pyright: ignore [reportMissingImports]
 
-            py_db = pydevd.get_global_debugger()
+            if (py_db := pydevd.get_global_debugger()) is None:
+                return
+
+            py_db = cast("pydevd.PyDB", py_db)
             thread = threading.current_thread()
             additional_info = py_db.set_additional_thread_info(thread)
             additional_info.is_tracing += 1

--- a/src/pymmcore_gui/_app.py
+++ b/src/pymmcore_gui/_app.py
@@ -97,7 +97,8 @@ def main() -> None:
     win.showMaximized()
     win.show()
 
-    if "_PYI_SPLASH_IPC" in os.environ and importlib.util.find_spec("pyi_splash"):
+    splsh = "_PYI_SPLASH_IPC" in os.environ and importlib.util.find_spec("pyi_splash")
+    if splsh:  # pragma: no cover
         import pyi_splash  # pyright: ignore [reportMissingModuleSource]
 
         pyi_splash.update_text("UI Loaded ...")
@@ -173,7 +174,7 @@ def ndv_excepthook(
         (debugpy := sys.modules.get("debugpy"))
         and debugpy.is_client_connected()
         and ("pydevd" in sys.modules)
-    ):
+    ):  # pragma: no cover
         with suppress(Exception):
             import threading
 

--- a/src/pymmcore_gui/_main_window.py
+++ b/src/pymmcore_gui/_main_window.py
@@ -164,7 +164,7 @@ class MicroManagerGUI(QMainWindow):
                     f"Action {key} has not been created yet, and 'create' is False"
                 )
             # create and cache it
-            info = WidgetActionInfo.for_key(key)
+            info: WidgetActionInfo[QWidget] = WidgetActionInfo.for_key(key)
             self._qactions[key] = action = info.to_qaction(self._mmc, self)
             # connect WidgetActions to toggle their widgets
             if isinstance(action.key, WidgetAction):

--- a/src/pymmcore_gui/actions/widget_actions.py
+++ b/src/pymmcore_gui/actions/widget_actions.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Generic, TypeVar, cast
 
 from pymmcore_plus import CMMCorePlus
 from PyQt6.QtCore import Qt
@@ -135,7 +135,7 @@ class WidgetAction(ActionKey):
 
     def create_widget(self, parent: QWidget) -> QWidget:
         """Create the widget associated with this action."""
-        info = WidgetActionInfo.for_key(self)
+        info: WidgetActionInfo[QWidget] = WidgetActionInfo.for_key(self)
         if not info.create_widget:
             raise NotImplementedError(f"No constructor has been provided for {self!r}")
         return info.create_widget(parent)
@@ -147,15 +147,17 @@ class WidgetAction(ActionKey):
 
 # ######################## WidgetActionInfos #########################
 
+WT = TypeVar("WT", bound="QWidget")
+
 
 @dataclass
-class WidgetActionInfo(ActionInfo):
+class WidgetActionInfo(ActionInfo, Generic[WT]):
     """Subclass to set default values for WidgetAction."""
 
     # by default, widget actions are checkable, and the check state indicates visibility
     checkable: bool = True
     # function that can be called with (parent: QWidget) -> QWidget
-    create_widget: Callable[[QWidget], QWidget] | None = None
+    create_widget: Callable[[QWidget], WT] | None = None
     # Use None to indicate that the widget should not be docked
     dock_area: Qt.DockWidgetArea | None = Qt.DockWidgetArea.RightDockWidgetArea
 

--- a/src/pymmcore_gui/widgets/_exception_log.py
+++ b/src/pymmcore_gui/widgets/_exception_log.py
@@ -27,7 +27,9 @@ from pymmcore_gui import _app
 
 if TYPE_CHECKING:
     from types import TracebackType
-    from typing import Never, TypeAlias
+    from typing import TypeAlias
+
+    from typing_extensions import Never
 
     ExcInfo: TypeAlias = tuple[type[BaseException], BaseException, TracebackType | None]
 

--- a/src/pymmcore_gui/widgets/_mm_console.py
+++ b/src/pymmcore_gui/widgets/_mm_console.py
@@ -31,6 +31,8 @@ if TYPE_CHECKING:
     from PyQt6.QtGui import QCloseEvent
     from PyQt6.QtWidgets import QWidget
 
+    # RichJupyterWidget has a very complex inheritance structure, and mypy/pyright
+    # are unable to determine that it is a QWidget subclass. This is a workaround.
     class RichJupyterWidget(RichJupyterWidget, QWidget): ...  # type: ignore[no-redef]
 
 

--- a/src/pymmcore_gui/widgets/_mm_console.py
+++ b/src/pymmcore_gui/widgets/_mm_console.py
@@ -18,7 +18,6 @@ if os.name == "nt":
 
 from PyQt6.QtWidgets import QApplication
 from qtconsole.inprocess import QtInProcessKernelManager
-from qtconsole.rich_jupyter_widget import RichJupyterWidget
 from traitlets import default
 
 try:
@@ -30,13 +29,16 @@ if TYPE_CHECKING:
     from ipykernel.inprocess.ipkernel import InProcessInteractiveShell, InProcessKernel
     from PyQt6.QtGui import QCloseEvent
     from PyQt6.QtWidgets import QWidget
+    from qtconsole.rich_jupyter_widget import RichJupyterWidget
 
     # RichJupyterWidget has a very complex inheritance structure, and mypy/pyright
     # are unable to determine that it is a QWidget subclass. This is a workaround.
-    class RichJupyterWidget(RichJupyterWidget, QWidget): ...  # type: ignore[no-redef]
+    class QtConsole(RichJupyterWidget, QWidget): ...  # pyright: ignore [reportIncompatibleMethodOverride]
+else:
+    from qtconsole.rich_jupyter_widget import RichJupyterWidget as QtConsole
 
 
-class MMConsole(RichJupyterWidget):
+class MMConsole(QtConsole):
     """A Qt widget for an IPython console, providing access to UI components."""
 
     def __init__(self, parent: QWidget | None = None) -> None:

--- a/src/pymmcore_gui/widgets/_mm_console.py
+++ b/src/pymmcore_gui/widgets/_mm_console.py
@@ -31,6 +31,8 @@ if TYPE_CHECKING:
     from PyQt6.QtGui import QCloseEvent
     from PyQt6.QtWidgets import QWidget
 
+    class RichJupyterWidget(RichJupyterWidget, QWidget): ...  # type: ignore[no-redef]
+
 
 class MMConsole(RichJupyterWidget):
     """A Qt widget for an IPython console, providing access to UI components."""
@@ -108,7 +110,7 @@ class MMConsole(RichJupyterWidget):
         """Return the variables pushed to the console."""
         return {k: v for k, v in self.shell.user_ns.items() if k != "__builtins__"}
 
-    def closeEvent(self, event: QCloseEvent) -> None:
+    def closeEvent(self, a0: QCloseEvent | None) -> None:
         """Clean up the integrated console."""
         if self.kernel_client is not None:
             self.kernel_client.stop_channels()
@@ -118,5 +120,6 @@ class MMConsole(RichJupyterWidget):
         # RichJupyterWidget doesn't clean these up
         self._completion_widget.deleteLater()
         self._call_tip_widget.deleteLater()
-        cast("QWidget", self).deleteLater()
-        event.accept()
+        self.deleteLater()
+        if a0 is not None:
+            a0.accept()

--- a/src/pymmcore_gui/widgets/_stage_control.py
+++ b/src/pymmcore_gui/widgets/_stage_control.py
@@ -48,8 +48,8 @@ class StagesControlWidget(QWidget):
         self._clear()
 
         stages = chain(
-            self._mmc.getLoadedDevicesOfType(DeviceType.XYStage),
-            self._mmc.getLoadedDevicesOfType(DeviceType.Stage),
+            self._mmc.getLoadedDevicesOfType(DeviceType.XYStage),  # pyright: ignore [reportArgumentType]
+            self._mmc.getLoadedDevicesOfType(DeviceType.Stage),  # pyright: ignore [reportArgumentType]
         )
         for idx, stage_dev in enumerate(stages):
             bx = _Group(stage_dev, self)

--- a/src/pymmcore_gui/widgets/_toolbars.py
+++ b/src/pymmcore_gui/widgets/_toolbars.py
@@ -61,7 +61,8 @@ class ShuttersToolbar(QToolBar):
 
     def _on_cfg_loaded(self) -> None:
         self._clear()
-        if not (shutters := self.mmc.getLoadedDevicesOfType(DeviceType.ShutterDevice)):
+        shutters = self.mmc.getLoadedDevicesOfType(DeviceType.ShutterDevice)  # pyright: ignore [reportArgumentType]
+        if not shutters:
             return
 
         shutters_devs = sorted(

--- a/uv.lock
+++ b/uv.lock
@@ -1380,6 +1380,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pyautogui" },
     { name = "pyinstaller" },
+    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-qt" },
@@ -1415,6 +1416,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.0.1" },
     { name = "pyautogui", specifier = ">=0.9.54" },
     { name = "pyinstaller", specifier = ">=6.11.1" },
+    { name = "pyright", specifier = ">=1.1.392.post0" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "pytest-qt", specifier = ">=4.4.0" },
@@ -1625,6 +1627,19 @@ name = "pyrect"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cb/04/2ba023d5f771b645f7be0c281cdacdcd939fe13d1deb331fc5ed1a6b3a98/PyRect-0.2.0.tar.gz", hash = "sha256:f65155f6df9b929b67caffbd57c0947c5ae5449d3b580d178074bffb47a09b78", size = 17219 }
+
+[[package]]
+name = "pyright"
+version = "1.1.392.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/df/3c6f6b08fba7ccf49b114dfc4bb33e25c299883fd763f93fad47ef8bc58d/pyright-1.1.392.post0.tar.gz", hash = "sha256:3b7f88de74a28dcfa90c7d90c782b6569a48c2be5f9d4add38472bdaac247ebd", size = 3789911 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/b1/a18de17f40e4f61ca58856b9ef9b0febf74ff88978c3f7776f910071f567/pyright-1.1.392.post0-py3-none-any.whl", hash = "sha256:252f84458a46fa2f0fd4e2f91fc74f50b9ca52c757062e93f6c250c0d8329eb2", size = 5595487 },
+]
 
 [[package]]
 name = "pyscreeze"


### PR DESCRIPTION
though mypy is community "standard".  pyright is a great type checker.  often faster with more configurability.  

This sets up pyright as an additional option and runs it manually in `ci.yml` (but not in pre-commit.ci due to environment creation limits).  That does mean we're "duplicating" type checking. and could conceivably remove the mypy-section from pre-commit (since it's quite ugly and verbose).  But i'm not doing that here yet either, because pre-commit is nice to run locally.  it's a long story :joy:, anyone please feel free to ask if you'd like to know more