### PR TITLE
docs: add link to latest bundles in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ for [`pymmcore-plus`](https://github.com/pymmcore-plus/pymmcore-plus) &
 
   See [CONTRIBUTING](CONTRIBUTING.md) for local setup instructions.
 
+  You can download the latest nightly bundled applications [here](https://nightly.link/pymmcore-plus/pymmcore-gui/workflows/bundle/main)
+
 </details>
 
 ## Goals (and non-goals) of unification


### PR DESCRIPTION
this adds the links to the bundled "nightly" app to the readme