### PR TITLE
build: use UV_FROZEN not UV_LOCKED

### DIFF
--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Install the project
         run: uv sync --all-extras --dev
+        env:
+          UV_LOCKED: ${{ github.ref_name == 'main' && 1 || 0 }}
 
       - name: Bundle
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     name: ${{ matrix.platform }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.platform }}
     env:
-      UV_LOCKED: true
+      UV_FROZEN: true
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
@fdrgsp , I this will solve the uv.lock issues you're seeing in #19 

according to https://docs.astral.sh/uv/concepts/projects/sync/#checking-if-the-lockfile-is-up-to-date:

> To avoid updating the lockfile during uv sync and uv run invocations, use the --frozen flag.
>
> To assert the lockfile matches the project metadata, use the --locked flag. If the lockfile is not up-to-date, an error will be raised instead of updating the lockfile.

all we really want to do is ensure that the lock file doesn't update while running tests.  I don't think we need to assert that it *wouldn't*, since that might be a bit more specific to the uv version.  I still don't have an answer as to why/when the lockfile is getting changed (when pyproject hasn't been touched).  