### PR TITLE
Change window title

### DIFF
--- a/src/pymmcore_gui/_main_window.py
+++ b/src/pymmcore_gui/_main_window.py
@@ -95,7 +95,7 @@ class MicroManagerGUI(QMainWindow):
 
     def __init__(self, *, mmcore: CMMCorePlus | None = None) -> None:
         super().__init__()
-        self.setWindowTitle("Mike")
+        self.setWindowTitle("MicroManagerGUI")
         self.setObjectName("MicroManagerGUI")
 
         # Serves to cache created QAction objects so that they can be re-used


### PR DESCRIPTION
@tlambert03 I'm assuming it wasn't deliberate to name the window "Mike" 😆

Lots of options here, including:
* PyMMCore GUI (matching the repo)
* mmgui (matching the entry point)
* MicroManagerGUI

I actually kinda like the first one - opinions welcome (cc @tlambert03 @fdrgsp @marktsuchida)