### PR TITLE
fix: Make `get_widget` always return the inner widget

### DIFF
--- a/src/pymmcore_gui/_main_window.py
+++ b/src/pymmcore_gui/_main_window.py
@@ -278,6 +278,11 @@ class MicroManagerGUI(QMainWindow):
     def get_dock_widget(self, key: WidgetAction) -> QDockWidget:
         """Get the QDockWidget for `key`.
 
+        Note, you can also get the QDockWidget by calling `get_widget(key)`, and then
+        calling `widget.parent()`.  The parent will *either* be an instance of
+        `QDockWidget` (if it's actually a docked widget), or `MicroManagerGUI`, if
+        it's not docked.  You *should* use `isisinstance` in this case to check.
+
         Parameters
         ----------
         key : WidgetAction

--- a/src/pymmcore_gui/_main_window.py
+++ b/src/pymmcore_gui/_main_window.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 from collections import ChainMap
 from enum import Enum
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Literal, cast, overload
 from weakref import WeakValueDictionary
 
 from pymmcore_plus import CMMCorePlus
+from pymmcore_widgets import ConfigWizard
 from PyQt6.QtGui import QAction, QCloseEvent
 from PyQt6.QtWidgets import (
     QDialog,
@@ -29,6 +30,21 @@ from .widgets._toolbars import OCToolBar, ShuttersToolbar
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
+
+    from pymmcore_widgets import (
+        CameraRoiWidget,
+        ConfigWizard,
+        GroupPresetTableWidget,
+        InstallWidget,
+        MDAWidget,
+        PixelConfigurationWidget,
+        PropertyBrowser,
+    )
+
+    from pymmcore_gui.widgets._about_widget import AboutWidget
+    from pymmcore_gui.widgets._exception_log import ExceptionLog
+    from pymmcore_gui.widgets._mm_console import MMConsole
+    from pymmcore_gui.widgets._stage_control import StagesControlWidget
 
 
 class Menu(str, Enum):
@@ -179,6 +195,35 @@ class MicroManagerGUI(QMainWindow):
 
         return self._qactions[key]
 
+    # TODO: it's possible this could be expressed using Generics...
+    # which would avoid the need for the manual overloads
+    # fmt: off
+    @overload
+    def get_widget(self, key: Literal[WidgetAction.ABOUT], create: bool = ...) -> AboutWidget: ...  # noqa: E501
+    @overload
+    def get_widget(self, key: Literal[WidgetAction.CAMERA_ROI], create: bool = ...) -> CameraRoiWidget: ...  # noqa: E501
+    @overload
+    def get_widget(self, key: Literal[WidgetAction.CONFIG_GROUPS], create: bool = ...) -> GroupPresetTableWidget: ...  # noqa: E501
+    @overload
+    def get_widget(self, key: Literal[WidgetAction.CONFIG_WIZARD], create: bool = ...) -> ConfigWizard: ...  # noqa: E501
+    @overload
+    def get_widget(self, key: Literal[WidgetAction.CONSOLE], create: bool = ...) -> MMConsole: ...  # noqa: E501
+    @overload
+    def get_widget(self, key: Literal[WidgetAction.EXCEPTION_LOG], create: bool = ...) -> ExceptionLog: ...  # noqa: E501
+    @overload
+    def get_widget(self, key: Literal[WidgetAction.INSTALL_DEVICES], create: bool = ...) -> InstallWidget: ...  # noqa: E501
+    @overload
+    def get_widget(self, key: Literal[WidgetAction.MDA_WIDGET], create: bool = ...) -> MDAWidget: ...  # noqa: E501
+    @overload
+    def get_widget(self, key: Literal[WidgetAction.PIXEL_CONFIG], create: bool = ...) -> PixelConfigurationWidget: ...  # noqa: E501
+    @overload
+    def get_widget(self, key: Literal[WidgetAction.PROP_BROWSER], create: bool = ...) -> PropertyBrowser: ...  # noqa: E501
+    @overload
+    def get_widget(self, key: Literal[WidgetAction.STAGE_CONTROL], create: bool = ...) -> StagesControlWidget: ...  # noqa: E501
+    # generic fallback
+    @overload
+    def get_widget(self, key: WidgetAction, create: bool = ...) -> QWidget: ...
+    # fmt: off
     def get_widget(self, key: WidgetAction, create: bool = True) -> QWidget:
         """Get (or create) widget for `key`.
 
@@ -216,6 +261,7 @@ class MicroManagerGUI(QMainWindow):
             if isinstance(widget, QDialog):
                 widget.finished.connect(_closeEvent)
 
+            # If this key specifies a dock area, create a QDockWidget for it
             if dock_area := key.dock_area():
                 self._dock_widgets[key] = dw = QDockWidget(key.value, self)
                 dw.setWidget(widget)
@@ -227,7 +273,27 @@ class MicroManagerGUI(QMainWindow):
             if action := self._qactions.get(key):
                 action.setChecked(True)
 
-        return self._qwidgets[key]
+        return self._inner_widgets[key]
+
+    def get_dock_widget(self, key: WidgetAction) -> QDockWidget:
+        """Get the QDockWidget for `key`.
+
+        Parameters
+        ----------
+        key : WidgetAction
+            The key for the *inner* widget owned by the requested QDockWidget.
+
+        Raises
+        ------
+        KeyError
+            If the widget doesn't exist.
+        """
+        if key not in self._dock_widgets:
+            raise KeyError(
+                f"Dock widget for {key} has not been created yet, "
+                "or it is not owned by a dock widget"
+            )
+        return self._dock_widgets[key]
 
     def _toggle_action_widget(self, checked: bool) -> None:
         """Callback that toggles the visibility of a widget.

--- a/src/pymmcore_gui/_main_window.py
+++ b/src/pymmcore_gui/_main_window.py
@@ -182,7 +182,7 @@ class MicroManagerGUI(QMainWindow):
     def get_action(self, key: ActionKey, create: bool = True) -> QAction:
         """Create a QAction from this key."""
         if key not in self._qactions:
-            if not create:
+            if not create:  # pragma: no cover
                 raise KeyError(
                     f"Action {key} has not been created yet, and 'create' is False"
                 )
@@ -223,7 +223,7 @@ class MicroManagerGUI(QMainWindow):
     # generic fallback
     @overload
     def get_widget(self, key: WidgetAction, create: bool = ...) -> QWidget: ...
-    # fmt: off
+    # fmt: on
     def get_widget(self, key: WidgetAction, create: bool = True) -> QWidget:
         """Get (or create) widget for `key`.
 
@@ -240,7 +240,7 @@ class MicroManagerGUI(QMainWindow):
             If the widget doesn't exist and `create` is False.
         """
         if key not in self._qwidgets:
-            if not create:
+            if not create:  # pragma: no cover
                 raise KeyError(
                     f"Widget {key} has not been created yet, and 'create' is False"
                 )
@@ -294,7 +294,7 @@ class MicroManagerGUI(QMainWindow):
             If the widget doesn't exist.
         """
         if key not in self._dock_widgets:
-            raise KeyError(
+            raise KeyError(  # pragma: no cover
                 f"Dock widget for {key} has not been created yet, "
                 "or it is not owned by a dock widget"
             )

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pymmcore_widgets
+from PyQt6.QtWidgets import QDockWidget
+
 from pymmcore_gui import CoreAction, MicroManagerGUI, WidgetAction
 
 if TYPE_CHECKING:
@@ -20,3 +23,8 @@ def test_main_window(qtbot: QtBot) -> None:
     for c_action in CoreAction:
         gui.get_action(c_action)
         assert c_action in gui._qactions
+
+    assert isinstance(
+        gui.get_widget(WidgetAction.MDA_WIDGET), pymmcore_widgets.MDAWidget
+    )
+    assert isinstance(gui.get_dock_widget(WidgetAction.MDA_WIDGET), QDockWidget)


### PR DESCRIPTION
Calling `MicroManagerGui.get_widget()` may sometimes return a QDockWidget, and sometimes the inner widget... which is confusing.  This makes it that `get_widget` *always* returns the expected actual widget, and adds manual overloads to make the typing work out correctly so that you know exactly what widget type you're dealing with.  Also adds a `get_dock_widget` method in the case where you actually want the dock widget itself