### PR TITLE
fix: fix shutter toolbar when loading a new configuration

### DIFF
--- a/src/pymmcore_gui/widgets/_toolbars.py
+++ b/src/pymmcore_gui/widgets/_toolbars.py
@@ -56,11 +56,16 @@ class ShuttersToolbar(QToolBar):
     ) -> None:
         super().__init__("Shutters", parent)
         self.mmc = mmc
+        # store all shutters widgets so that can be deleted when a new configuration is
+        # loaded
+        self._wdg: list[ShuttersWidget] = []
         self.mmc.events.systemConfigurationLoaded.connect(self._on_cfg_loaded)
         self._on_cfg_loaded()
 
     def _on_cfg_loaded(self) -> None:
-        # self._clear()
+        # delete all current shutter widgets and actions if any
+        self._clear_shutter_toolbar()
+
         shutters = self.mmc.getLoadedDevicesOfType(DeviceType.ShutterDevice)  # pyright: ignore [reportArgumentType]
         if not shutters:
             return
@@ -77,12 +82,14 @@ class ShuttersToolbar(QToolBar):
             s = ShuttersWidget(shutter, autoshutter=idx == len(shutters_devs) - 1)
             s.button_text_open = shutter
             s.button_text_closed = shutter
-            # s.icon_color_open = ()
-            # s.icon_color_closed = ()
             self.addWidget(s)
+            self._wdg.append(s)
 
-    # def _clear(self) -> None:
-    #     """Delete toolbar action."""
-    #     while self.actions():
-    #         action = self.actions()[0]
-    #         self.removeAction(action)
+    def _clear_shutter_toolbar(self) -> None:
+        """Delete all shutter widgets and actions in the toolbar."""
+        while self._wdg:
+            wdg = self._wdg.pop()
+            wdg.deleteLater()
+        while self.actions():
+            action = self.actions()[0]
+            self.removeAction(action)

--- a/src/pymmcore_gui/widgets/_toolbars.py
+++ b/src/pymmcore_gui/widgets/_toolbars.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from typing import cast
 
 from pymmcore_plus import CMMCorePlus, DeviceType

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -44,11 +44,12 @@ def test_shutter_toolbar(qtbot: QtBot, qapp: QApplication, tmp_path) -> None:
     assert isinstance(sh_toolbar, ShuttersToolbar)
 
     # in our test cfg we have 3 shutters
-    assert sh_toolbar.layout().count() == 3
+    assert sh_toolbar.layout().count() == 3  # pyright: ignore
     assert len(sh_toolbar.actions()) == 3
 
     # loading default cfg
     gui._mmc.loadSystemConfiguration()
     # in our test cfg we have 2 shutters
-    assert sh_toolbar.layout().count() == 2
+    assert sh_toolbar.layout().count() == 2  # pyright: ignore
     assert len(sh_toolbar.actions()) == 2
+

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from pymmcore_plus import DeviceType
 
 from pymmcore_widgets import MDAWidget
 from PyQt6.QtWidgets import QApplication, QDialog, QDockWidget
 
 from pymmcore_gui import CoreAction, MicroManagerGUI, WidgetAction
+from pymmcore_gui._main_window import Toolbar
+from pymmcore_gui.widgets._toolbars import ShuttersToolbar
 
 if TYPE_CHECKING:
     from pytestqt.qtbot import QtBot
@@ -30,3 +33,24 @@ def test_main_window(qtbot: QtBot, qapp: QApplication) -> None:
 
     assert isinstance(gui.get_widget(WidgetAction.MDA_WIDGET), MDAWidget)
     assert isinstance(gui.get_dock_widget(WidgetAction.MDA_WIDGET), QDockWidget)
+
+
+def test_shutter_toolbar(qtbot: QtBot, qapp: QApplication, tmp_path) -> None:
+    # make sure that when we load a new cfg the shutters toolbar is updated
+    gui = MicroManagerGUI()
+    qtbot.addWidget(gui)
+
+    sh_toolbar = gui.TOOLBARS[Toolbar.SHUTTERS](gui._mmc, gui)  # type: ignore
+    assert sh_toolbar is not None
+    assert isinstance(sh_toolbar, ShuttersToolbar)
+
+    # in our test cfg we have 3 shutters
+    assert len(sh_toolbar._wdg) == 3
+    assert len(sh_toolbar.actions()) == 3
+
+    # loading default cfg
+    gui._mmc.loadSystemConfiguration()
+    print(gui._mmc.getLoadedDevicesOfType(DeviceType.Shutter))
+    # in our test cfg we have 2 shutters
+    assert len(sh_toolbar._wdg) == 2
+    assert len(sh_toolbar.actions()) == 2

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -45,12 +45,11 @@ def test_shutter_toolbar(qtbot: QtBot, qapp: QApplication, tmp_path) -> None:
     assert isinstance(sh_toolbar, ShuttersToolbar)
 
     # in our test cfg we have 3 shutters
-    assert len(sh_toolbar._wdg) == 3
+    assert sh_toolbar.layout().count() == 3
     assert len(sh_toolbar.actions()) == 3
 
     # loading default cfg
     gui._mmc.loadSystemConfiguration()
-    print(gui._mmc.getLoadedDevicesOfType(DeviceType.Shutter))
     # in our test cfg we have 2 shutters
-    assert len(sh_toolbar._wdg) == 2
+    assert sh_toolbar.layout().count() == 2
     assert len(sh_toolbar.actions()) == 2

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from pymmcore_plus import DeviceType
 from pymmcore_widgets import MDAWidget
 from PyQt6.QtWidgets import QApplication, QDialog, QDockWidget
 

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from pymmcore_plus import DeviceType
 
+from pymmcore_plus import DeviceType
 from pymmcore_widgets import MDAWidget
 from PyQt6.QtWidgets import QApplication, QDialog, QDockWidget
 

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -52,4 +52,3 @@ def test_shutter_toolbar(qtbot: QtBot, qapp: QApplication, tmp_path) -> None:
     # in our test cfg we have 2 shutters
     assert sh_toolbar.layout().count() == 2  # pyright: ignore
     assert len(sh_toolbar.actions()) == 2
-


### PR DESCRIPTION
We have an issue with the shutter widget toolbar when loading a new configuration. If a shutter with the same name does not exist in the new configuration, we get shutter widgets with `None`.

This PR clears the shutter toolbar before updating it with the new shutter devices.

---
<img width="1153" alt="Screenshot 2025-02-10 at 3 07 14 PM" src="https://github.com/user-attachments/assets/7844cd83-16b4-48f6-b96b-565604593427" />



