### PR TITLE
fix: fix tests by retaining app pointer

### DIFF
--- a/src/pymmcore_gui/_app.py
+++ b/src/pymmcore_gui/_app.py
@@ -75,7 +75,7 @@ def parse_args(args: Sequence[str] = ()) -> argparse.Namespace:
     return parser.parse_args(args)
 
 
-def main() -> None:
+def main() -> MMQApplication:
     """Run the Micro-Manager GUI."""
     args = parse_args()
 
@@ -105,6 +105,14 @@ def main() -> None:
         pyi_splash.close()
 
     app.exec()
+
+    # NOTE:
+    # the fact that we're returning the app instance after exec() is a little odd.
+    # it's there for testing so that `test_app::test_main_app` can retain a reference
+    # to the application for the scope of the test.
+    # I also tried retaining a global app reference within this module, but that led
+    # to consistent segfaults for reasons I don't understand.
+    return app
 
 
 # ------------------- Custom excepthook -------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ import pytest
 from pymmcore_plus import CMMCorePlus, configure_logging
 from pymmcore_plus.core import _mmcore_plus
 
-from pymmcore_gui import settings
+from pymmcore_gui import _app, settings
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -34,6 +34,11 @@ if TYPE_CHECKING:
 TEST_CONFIG = str(Path(__file__).parent / "test_config.cfg")
 
 configure_logging(stderr_level="CRITICAL")
+
+
+@pytest.fixture(scope="session")
+def qapp_cls() -> type[QApplication]:
+    return _app.MMQApplication
 
 
 # to create a new CMMCorePlus() for every test

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -11,8 +11,9 @@ def test_main_app(monkeypatch: MonkeyPatch) -> None:
     mock_exec = Mock()
     monkeypatch.setattr(QApplication, "exec", mock_exec)
     monkeypatch.setattr(sys, "argv", ["mmgui"])
-    _app.main()
+    _ = _app.main()  # must retain handle for scope of this test.
     mock_exec.assert_called_once()
+    assert QApplication.instance()
     assert isinstance(QApplication.instance(), _app.MMQApplication)
     assert sys.excepthook == _app.ndv_excepthook
     for wdg in QApplication.topLevelWidgets():


### PR DESCRIPTION
fixes a test failing we're seeing in #41 

it's an odd failure, caused by the app going out of scope too quickly