### PR TITLE
fix: remove showMaximized from main()

### DIFF
--- a/src/pymmcore_gui/_app.py
+++ b/src/pymmcore_gui/_app.py
@@ -91,7 +91,6 @@ def main() -> MMQApplication:
     except Exception as e:
         print(f"Failed to load system configuration: {e}")
 
-    win.showMaximized()
     win.show()
 
     splsh = "_PYI_SPLASH_IPC" in os.environ and importlib.util.find_spec("pyi_splash")


### PR DESCRIPTION
in some of my reversions before merging #38, I accidentally added back the `.showMaximized()` call in `main()`.  This removes it