### PR TITLE
fix: the OCToolBar widget should listen to propertyChanged 

### DIFF
--- a/src/pymmcore_gui/widgets/_toolbars.py
+++ b/src/pymmcore_gui/widgets/_toolbars.py
@@ -22,15 +22,16 @@ class OCToolBar(QToolBar):
         mmc.events.channelGroupChanged.connect(self._refresh)
         mmc.events.configSet.connect(self._on_config_set)
         mmc.events.propertyChanged.connect(self._on_property_changed)
-
         self._refresh()
 
     def _on_config_set(self, group: str, config: str) -> None:
+        """Update the checked action when a new config is set."""
         if group == self.mmc.getChannelGroup():
             for action in self.actions():
                 action.setChecked(action.text() == config)
 
     def _on_property_changed(self, device: str, property: str, value: str) -> None:
+        """Refresh the widget when the ChannelGroup property is changed."""
         if device == "Core" and property == "ChannelGroup":
             self._refresh()
 

--- a/src/pymmcore_gui/widgets/_toolbars.py
+++ b/src/pymmcore_gui/widgets/_toolbars.py
@@ -21,6 +21,7 @@ class OCToolBar(QToolBar):
         mmc.events.configGroupChanged.connect(self._refresh)
         mmc.events.channelGroupChanged.connect(self._refresh)
         mmc.events.configSet.connect(self._on_config_set)
+        mmc.events.propertyChanged.connect(self._on_property_changed)
 
         self._refresh()
 
@@ -28,6 +29,10 @@ class OCToolBar(QToolBar):
         if group == self.mmc.getChannelGroup():
             for action in self.actions():
                 action.setChecked(action.text() == config)
+
+    def _on_property_changed(self, device: str, property: str, value: str) -> None:
+        if device == "Core" and property == "ChannelGroup":
+            self._refresh()
 
     def _refresh(self) -> None:
         """Clear and refresh with all settings in current channel group."""


### PR DESCRIPTION
The OCToolBar widget should also listen to propertyChanged signal when the "Core" "ChannelGroup" is changed (e.g `mmc.setProperty("Core", "ChannelGroup", "Channel"`)