### PR TITLE
feat: add auto-error reporting via sentry

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,7 @@ repos:
       - id: markdownlint
         args: [
             --disable=MD033, # no-inline-html
+            --disable=MD036, # no-emphasis-as-heading
           ]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,93 @@
+# Privacy Policy
+
+This application includes *opt-in* error reporting powered by
+[Sentry](https://sentry.io), an open-source error monitoring service.
+
+## What We Collect
+
+If you choose to opt in to error reporting, we may collect the following
+information when an unhandled exception occurs:
+
+- Python tracebacks and exception details
+- Application version and Python version
+- Operating system name (e.g. "Darwin" or "Windows")
+- A randomly generated session identifier
+- Whether the application is a development version or installed from a package
+- A list of installed Python packages and their versions
+- The command used to launch the app, with personal paths removed
+
+> We make every effort to strip potentially sensitive information, such as home
+> directory paths and hostnames, before sending.
+
+## What We Don’t Collect
+
+We **do not collect**:
+
+- Names, email addresses, or any personal identifiers
+- User input, documents, or data files
+- IP addresses (Sentry is configured to avoid storing them)
+- Directory paths or filenames (these are stripped before sending)
+- Hostnames or computer names, unless you explicitly allow it via the
+  `MM_TELEMETRY_SHOW_HOSTNAME` environment variable.
+
+## When We Collect It
+
+Error reporting is **opt-in only**.  No data is sent without your consent.
+
+On program launch, you'll be asked whether you'd like to send crash reports.
+Your response is stored locally in a configuration file.  If you answer "Yes",
+the application will send error reports to Sentry when an unhandled exception
+occurs.
+
+## Opting out
+
+You can change your preference at any time in the Exception Log Window
+(restart required).
+
+## Transparency
+
+The complete error reporting logic is open source and viewable at:
+
+<https://github.com/pymmcore-plus/pymmcore-gui/blob/main/src/pymmcore_gui/_sentry_.py>
+
+## Data Retention
+
+Crash data may be stored by Sentry for up to **90 days** for debugging and
+quality improvement purposes.
+
+## Legal Basis for Processing (GDPR/UK GDPR)
+
+For users in the EU or UK, the legal basis for collecting crash reports is
+**your explicit consent** under Article 6(1)(a) of the GDPR. No data is
+collected unless you opt in.
+
+## Your Rights (for EU/UK Users)
+
+Under the GDPR, you have the right to access, delete, or object to the
+processing of your personal data.
+
+Note, we **do not collect any data that can be used to identify you**, and
+therefore have no way to link error reports to specific individuals. As a
+result, we are **unable to fulfill individual access or deletion requests**
+because we cannot associate any data with you.
+
+## Third-party Services (Sentry)
+
+Error reports are sent to:
+
+**Sentry**  
+Functional Software, Inc.
+45 Fremont Street, 8th Floor
+San Francisco, CA 94105
+Privacy Policy: [https://sentry.io/privacy/](https://sentry.io/privacy/)  
+Data Processing Agreement: [https://sentry.io/legal/dpa/](https://sentry.io/legal/dpa/)
+
+## Contact
+
+For any questions or concerns about this policy, feel free to [open an
+issue](https://github.com/pymmcore-plus/pymmcore-gui/issues/new) on our GitHub
+repository.
+
+---
+
+*Last updated: 2025-04-16*

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1% # allow minor coverage drops without failing
+        branches:     # only run status checks for PRs
+          - "!main"   # exclude the main branch from project coverage checks
+    patch:
+      default:
+        target: 85%
+        branches:
+          - "!main"   # exclude main branch from patch checks
+
+comment:
+  require_changes: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "pyright>=1.1.393",
     "pyyaml>=6.0.2",
     "qtconsole>=5.6.1",
-    "rich", # also in pymmcore-plus[cli] above
+    "rich",                         # also in pymmcore-plus[cli] above
     "superqt[cmap,iconify]>=0.7.1",
     "tifffile>=2024.12.12",
     "tqdm>=4.67.1",
@@ -174,6 +174,8 @@ exclude_lines = [
 
 [tool.coverage.run]
 source = ["pymmcore_gui"]
+omit = ["src/pymmcore_gui/_sentry.py"]
+
 
 [tool.check-manifest]
 ignore = [".pre-commit-config.yaml", ".ruff_cache/**/*", "tests/**/*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,11 +43,12 @@ dependencies = [
     "PyQt6==6.7.1",
     "pyyaml>=6.0.2",
     "qtconsole>=5.6.1",
-    "rich",                         # also in pymmcore-plus[cli] above
+    "rich", # also in pymmcore-plus[cli] above
     "superqt[cmap,iconify]>=0.7.1",
     "tifffile>=2024.12.12",
     "tqdm>=4.67.1",
     "zarr>=2.18.3,<3.0",
+    "sentry-sdk>=2.20.0",
 ]
 
 [tool.uv]

--- a/src/pymmcore_gui/_app.py
+++ b/src/pymmcore_gui/_app.py
@@ -105,7 +105,6 @@ def main() -> QCoreApplication:
         )
 
     _install_excepthook()
-    _sentry.install_error_reporter()
 
     win = MicroManagerGUI()
     QTimer.singleShot(0, lambda: win._restore_state(True))
@@ -126,6 +125,7 @@ def main() -> QCoreApplication:
         pyi_splash.update_text("UI Loaded ...")
         pyi_splash.close()
 
+    _sentry.install_error_reporter()
     app.exec()
 
     # NOTE:

--- a/src/pymmcore_gui/_app.py
+++ b/src/pymmcore_gui/_app.py
@@ -17,6 +17,8 @@ from superqt.utils import WorkerBase
 
 from pymmcore_gui import MicroManagerGUI, __version__
 
+from . import _sentry
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from types import TracebackType
@@ -81,6 +83,7 @@ def main() -> None:
 
     app = MMQApplication(sys.argv)
     _install_excepthook()
+    _sentry.install_error_reporter()
 
     win = MicroManagerGUI()
     win.setWindowIcon(QIcon(str(ICON)))

--- a/src/pymmcore_gui/_app.py
+++ b/src/pymmcore_gui/_app.py
@@ -73,12 +73,25 @@ def parse_args(args: Sequence[str] = ()) -> argparse.Namespace:
         help="Config file to load",
         nargs="?",
     )
+    parser.add_argument(
+        "--reset",
+        action="store_true",
+        default=False,
+        help="Reset settings to default values and exit.",
+    )
+
     return parser.parse_args(args)
 
 
 def main() -> QCoreApplication:
     """Run the Micro-Manager GUI."""
     args = parse_args()
+    if args.reset:
+        from pymmcore_gui._settings import reset_to_defaults
+
+        reset_to_defaults()
+        print("Settings reset to defaults.")
+        sys.exit(0)
 
     # Note: in practice this should almost never be None,
     # but in the case of testing, it's conceivable that it could be.

--- a/src/pymmcore_gui/_main_window.py
+++ b/src/pymmcore_gui/_main_window.py
@@ -31,9 +31,9 @@ from pymmcore_gui.actions.widget_actions import WidgetActionInfo
 
 from ._ndv_viewers import NDVViewersManager
 from ._notification_manager import NotificationManager
+from ._settings import Settings
 from .actions import CoreAction, WidgetAction
 from .actions._action_info import ActionKey
-from .settings import Settings
 
 try:
     from .widgets._pygfx_image import PygfxImagePreview as ImagePreview

--- a/src/pymmcore_gui/_sentry.py
+++ b/src/pymmcore_gui/_sentry.py
@@ -1,0 +1,163 @@
+import functools
+import os
+import platform
+import uuid
+from contextlib import suppress
+from importlib import metadata
+from pathlib import Path
+from site import getsitepackages, getusersitepackages
+from subprocess import run
+from typing import TYPE_CHECKING
+
+if not TYPE_CHECKING:
+    try:
+        from rich import print
+    except ImportError:  # pragma: no cover
+        from pprint import pprint as print
+
+
+SENTRY_DSN = "https://5dd4ce839a4257693e030b136b3ac126@o100671.ingest.us.sentry.io/4507535157952512"
+SHOW_HOSTNAME = os.getenv("MM_TELEMETRY_SHOW_HOSTNAME", "0") in ("1", "True")
+SHOW_LOCALS = os.getenv("MM_TELEMETRY_SHOW_LOCALS", "1") in ("1", "True")
+DEBUG = bool(os.getenv("MM_TELEMETRY_DEBUG"))
+
+
+def strip_sensitive_data(event: dict, hint: dict) -> dict:
+    """Pre-send hook to strip sensitive data from `event` dict.
+
+    https://docs.sentry.io/platforms/python/configuration/filtering/#filtering-error-events
+    """
+    # modify event here
+
+    # strip `abs_paths` from stack_trace to hide local paths
+    with suppress(KeyError, IndexError):
+        for exc in event["exception"]["values"]:
+            for frame in exc["stacktrace"]["frames"]:
+                frame.pop("abs_path", None)
+        # only include the name of the executable in sys.argv (remove pathsƒ)
+        if args := event["extra"]["sys.argv"]:
+            args[0] = args[0].split(os.sep)[-1]
+    if DEBUG:  # pragma: no cover
+        print(event)
+    return event
+
+
+def is_editable_install() -> bool:
+    """Return True if `dist_name` is installed as editable.
+
+    i.e: if the package isn't in site-packages or user site-packages.
+    """
+    root = str(Path(__import__("pymmcore_gui").__file__).parent)
+    installed_paths = [*getsitepackages(), getusersitepackages()]
+    return all(loc not in root for loc in installed_paths)
+
+
+def try_get_git_sha(dist_name: str = "micromanager-gui") -> str:
+    """Try to return a git sha, for `dist_name` and detect if dirty.
+
+    Return empty string on failure.
+    """
+    try:
+        ff = metadata.distribution(dist_name).locate_file("")
+        out = run(["git", "-C", ff, "rev-parse", "HEAD"], capture_output=True)
+        if out.returncode:  # pragma: no cover
+            return ""
+        sha = out.stdout.decode().strip()
+        # exit with 1 if there are differences and 0 means no differences
+        # disallow external diff drivers
+        out = run(["git", "-C", ff, "diff", "--no-ext-diff", "--quiet", "--exit-code"])
+        if out.returncode:  # pragma: no cover
+            sha += "-dirty"
+        return sha
+    except Exception:  # pragma: no cover
+        return ""
+
+
+@functools.lru_cache
+def get_release() -> str:
+    """Get the current release string for `package`.
+
+    If the package is an editable install, it will return the current git sha.
+    Otherwise return version string from package metadata.
+    """
+    with suppress(Exception):
+        if is_editable_install():
+            if sha := try_get_git_sha():
+                return sha
+        return metadata.version("micromanager-gui")
+    return "UNDETECTED"
+
+
+# https://docs.sentry.io/platforms/python/configuration/
+SENTRY_SETTINGS = {
+    "dsn": SENTRY_DSN,
+    # When enabled, local variables are sent along with stackframes.
+    # This can have a performance and PII impact.
+    # Enabled by default on platforms where this is available.
+    "include_local_variables": SHOW_LOCALS,
+    # A number between 0 and 1, controlling the percentage chance
+    # a given transaction will be sent to Sentry.
+    # (0 represents 0% while 1 represents 100%.)
+    # Applies equally to all transactions created in the app.
+    # Either this or traces_sampler must be defined to enable tracing.
+    "traces_sample_rate": 1.0,
+    # When provided, the name of the server is sent along and persisted
+    # in the event. For many integrations the server name actually
+    # corresponds to the device hostname, even in situations where the
+    # machine is not actually a server. Most SDKs will attempt to
+    # auto-discover this value. (computer name: potentially PII)
+    "server_name": None if SHOW_HOSTNAME else "",
+    # If this flag is enabled, certain personally identifiable information (PII)
+    # is added by active integrations. By default, no such data is sent.
+    "send_default_pii": False,
+    # This function is called with an SDK-specific event object, and can return a
+    # modified event object or nothing to skip reporting the event.
+    # This can be used, for instance, for manual PII stripping before sending.
+    "before_send": strip_sensitive_data,
+    "debug": DEBUG,
+    # Set profiles_sample_rate to 1.0 to profile 100%
+    # of sampled transactions.
+    # We recommend adjusting this value in production.
+    "profiles_sample_rate": 1.0,
+    # -------------------------
+    "environment": platform.system(),
+}
+
+
+@functools.lru_cache
+def get_tags() -> dict[str, str]:
+    """Get platform and other tags to associate with this session."""
+    tags = {"platform.platform": platform.platform()}
+
+    with suppress(ImportError):
+        import qtpy
+
+        tags["qtpy.API_NAME"] = qtpy.API_NAME
+        tags["qtpy.QT_VERSION"] = qtpy.QT_VERSION
+
+    with suppress(ModuleNotFoundError):
+        tags["editable_install"] = str(is_editable_install())
+
+    return tags
+
+
+SENTRY_INSTALLED = False
+
+
+def install_error_reporter() -> None:
+    """Initialize the error reporter with sentry.io."""
+    try:
+        import sentry_sdk
+    except ImportError:  # pragma: no cover
+        print("sentry-sdk not installed, skipping error reporting.")
+        return
+
+    global SENTRY_INSTALLED
+    if SENTRY_INSTALLED:
+        return  # pragma: no cover
+
+    sentry_sdk.init({**SENTRY_SETTINGS, "release": get_release()})
+    for k, v in get_tags().items():
+        sentry_sdk.set_tag(k, v)
+    sentry_sdk.set_user({"id": uuid.getnode()})
+    SENTRY_INSTALLED = True

--- a/src/pymmcore_gui/_sentry.py
+++ b/src/pymmcore_gui/_sentry.py
@@ -33,9 +33,7 @@ def strip_sensitive_data(event: Event, hint: Hint) -> Event | None:
 
     https://docs.sentry.io/platforms/python/configuration/filtering/#filtering-error-events
     """
-    # modify event here
-
-    # strip `abs_paths` from stack_trace to hide local paths
+    # strip home dir from `abs_paths` in stack_trace to hide local paths
     with suppress(Exception):
         if exception := event.get("exception"):
             for exc in exception.get("values", []):
@@ -89,7 +87,7 @@ def try_get_git_sha(dist_name: str = "pymmcore-gui") -> str:
         return ""
 
 
-@functools.lru_cache
+@functools.cache
 def get_release() -> str | None:
     """Get the current release string for `package`.
 
@@ -104,7 +102,7 @@ def get_release() -> str | None:
     return None
 
 
-@functools.lru_cache
+@functools.cache
 def get_tags() -> dict[str, str]:
     """Get platform and other tags to associate with this session."""
     tags = {"frozen": str(getattr(sys, "frozen", False))}

--- a/src/pymmcore_gui/_sentry.py
+++ b/src/pymmcore_gui/_sentry.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 import os
 import platform
@@ -9,12 +11,13 @@ from site import getsitepackages, getusersitepackages
 from subprocess import run
 from typing import TYPE_CHECKING
 
-if not TYPE_CHECKING:
+if TYPE_CHECKING:
+    from sentry_sdk._types import Event, Hint
+else:
     try:
         from rich import print
     except ImportError:  # pragma: no cover
         from pprint import pprint as print
-
 
 SENTRY_DSN = "https://5dd4ce839a4257693e030b136b3ac126@o100671.ingest.us.sentry.io/4507535157952512"
 SHOW_HOSTNAME = os.getenv("MM_TELEMETRY_SHOW_HOSTNAME", "0") in ("1", "True")
@@ -22,7 +25,7 @@ SHOW_LOCALS = os.getenv("MM_TELEMETRY_SHOW_LOCALS", "1") in ("1", "True")
 DEBUG = bool(os.getenv("MM_TELEMETRY_DEBUG"))
 
 
-def strip_sensitive_data(event: dict, hint: dict) -> dict:
+def strip_sensitive_data(event: Event, hint: Hint) -> Event | None:
     """Pre-send hook to strip sensitive data from `event` dict.
 
     https://docs.sentry.io/platforms/python/configuration/filtering/#filtering-error-events
@@ -31,11 +34,12 @@ def strip_sensitive_data(event: dict, hint: dict) -> dict:
 
     # strip `abs_paths` from stack_trace to hide local paths
     with suppress(KeyError, IndexError):
-        for exc in event["exception"]["values"]:
-            for frame in exc["stacktrace"]["frames"]:
-                frame.pop("abs_path", None)
-        # only include the name of the executable in sys.argv (remove pathsƒ)
-        if args := event["extra"]["sys.argv"]:
+        if exception := event.get("exception"):
+            for exc in exception.get("values", []):
+                for frame in exc.get("stacktrace", {}).get("frames", []):
+                    frame.pop("abs_path", None)
+        # only include the name of the executable in sys.argv (remove paths)
+        if (extra := event.get("extra")) and (args := extra.get("sys.argv")):
             args[0] = args[0].split(os.sep)[-1]
     if DEBUG:  # pragma: no cover
         print(event)
@@ -52,7 +56,7 @@ def is_editable_install() -> bool:
     return all(loc not in root for loc in installed_paths)
 
 
-def try_get_git_sha(dist_name: str = "micromanager-gui") -> str:
+def try_get_git_sha(dist_name: str = "pymmcore-gui") -> str:
     """Try to return a git sha, for `dist_name` and detect if dirty.
 
     Return empty string on failure.
@@ -84,44 +88,8 @@ def get_release() -> str:
         if is_editable_install():
             if sha := try_get_git_sha():
                 return sha
-        return metadata.version("micromanager-gui")
+        return metadata.version("pymmcore-gui")
     return "UNDETECTED"
-
-
-# https://docs.sentry.io/platforms/python/configuration/
-SENTRY_SETTINGS = {
-    "dsn": SENTRY_DSN,
-    # When enabled, local variables are sent along with stackframes.
-    # This can have a performance and PII impact.
-    # Enabled by default on platforms where this is available.
-    "include_local_variables": SHOW_LOCALS,
-    # A number between 0 and 1, controlling the percentage chance
-    # a given transaction will be sent to Sentry.
-    # (0 represents 0% while 1 represents 100%.)
-    # Applies equally to all transactions created in the app.
-    # Either this or traces_sampler must be defined to enable tracing.
-    "traces_sample_rate": 1.0,
-    # When provided, the name of the server is sent along and persisted
-    # in the event. For many integrations the server name actually
-    # corresponds to the device hostname, even in situations where the
-    # machine is not actually a server. Most SDKs will attempt to
-    # auto-discover this value. (computer name: potentially PII)
-    "server_name": None if SHOW_HOSTNAME else "",
-    # If this flag is enabled, certain personally identifiable information (PII)
-    # is added by active integrations. By default, no such data is sent.
-    "send_default_pii": False,
-    # This function is called with an SDK-specific event object, and can return a
-    # modified event object or nothing to skip reporting the event.
-    # This can be used, for instance, for manual PII stripping before sending.
-    "before_send": strip_sensitive_data,
-    "debug": DEBUG,
-    # Set profiles_sample_rate to 1.0 to profile 100%
-    # of sampled transactions.
-    # We recommend adjusting this value in production.
-    "profiles_sample_rate": 1.0,
-    # -------------------------
-    "environment": platform.system(),
-}
 
 
 @functools.lru_cache
@@ -156,7 +124,39 @@ def install_error_reporter() -> None:
     if SENTRY_INSTALLED:
         return  # pragma: no cover
 
-    sentry_sdk.init({**SENTRY_SETTINGS, "release": get_release()})
+    sentry_sdk.init(
+        SENTRY_DSN,
+        # When enabled, local variables are sent along with stackframes.
+        # This can have a performance and PII impact.
+        # Enabled by default on platforms where this is available.
+        include_local_variables=SHOW_LOCALS,
+        # A number between 0 and 1, controlling the percentage chance
+        # a given transaction will be sent to Sentry.
+        # (0 represents 0% while 1 represents 100%.)
+        # Applies equally to all transactions created in the app.
+        # Either this or traces_sampler must be defined to enable tracing.
+        traces_sample_rate=1.0,
+        # When provided, the name of the server is sent along and persisted
+        # in the event. For many integrations the server name actually
+        # corresponds to the device hostname, even in situations where the
+        # machine is not actually a server. Most SDKs will attempt to
+        # auto-discover this value. (computer name: potentially PII)
+        server_name=None if SHOW_HOSTNAME else "",
+        # If this flag is enabled, certain personally identifiable information (PII)
+        # is added by active integrations. By default, no such data is sent.
+        send_default_pii=False,
+        # This function is called with an SDK-specific event object, and can return a
+        # modified event object or nothing to skip reporting the event.
+        # This can be used, for instance, for manual PII stripping before sending.
+        before_send=strip_sensitive_data,
+        debug=DEBUG,
+        # Set profiles_sample_rate to 1.0 to profile 100%
+        # of sampled transactions.
+        # TODO: recommend adjusting this value in production.
+        profiles_sample_rate=1.0,
+        release=get_release(),
+        environment=platform.system(),
+    )
     for k, v in get_tags().items():
         sentry_sdk.set_tag(k, v)
     sentry_sdk.set_user({"id": uuid.getnode()})

--- a/src/pymmcore_gui/_sentry.py
+++ b/src/pymmcore_gui/_sentry.py
@@ -215,7 +215,7 @@ Please help us fix bugs by allowing us to collect crash and exception reports.
 <li><strong>No</strong> personally identifiable information is collected.</li>
 <li>We collect tracebacks that show where errors occur.</li>
 <li>We collect program, and python versions.</li>
-<li>Error-reporting logic is available in the
+<li>Error-reporting logic is viewable in the
 <a href="https://github.com/pymmcore-plus/pymmcore-gui/blob/main/src/pymmcore_gui/_utils.py">
 source code</a>.</li>
 </ul>

--- a/src/pymmcore_gui/_sentry.py
+++ b/src/pymmcore_gui/_sentry.py
@@ -220,7 +220,7 @@ Please help us fix bugs by allowing us to collect crash and exception reports.
 source code</a>.</li>
 </ul>
 
-You can disable this at any time in the settings dialog.
+You can disable this at any time in the Exception Log Window.
         """
         )
         txt.setWordWrap(True)

--- a/src/pymmcore_gui/_sentry.py
+++ b/src/pymmcore_gui/_sentry.py
@@ -196,7 +196,7 @@ def install_error_reporter() -> None:  # pragma: no cover
     SENTRY_INSTALLED = True
 
 
-class SendErrorsDialog(QDialog):
+class OptInDialog(QDialog):
     """Dialog to ask the user if they want to send error reports."""
 
     def __init__(self) -> None:
@@ -206,7 +206,7 @@ class SendErrorsDialog(QDialog):
         layout = QVBoxLayout()
         txt = QLabel(
             """
-<h2>Help us improve?</h2>
+<h2>&#128591; Help us improve pymmcore-gui?</h2>
 
 <p>
 Please help us fix bugs by allowing us to collect crash and exception reports.
@@ -220,14 +220,16 @@ Please help us fix bugs by allowing us to collect crash and exception reports.
 source code</a>.</li>
 </ul>
 
-You can disable this at any time in the Exception Log Window.
-        """
+You can disable this at any time in the Exception Log Window.</p><br>
+<em><small>
+<a href="https://github.com/pymmcore-plus/pymmcore-gui/blob/main/PRIVACY.md">
+Privacy Policy</a></small></em>"""
         )
         txt.setWordWrap(True)
         txt.setOpenExternalLinks(True)
         layout.addWidget(txt)
         button_box = QDialogButtonBox(
-            QDialogButtonBox.StandardButton.No | QDialogButtonBox.StandardButton.Ok
+            QDialogButtonBox.StandardButton.No | QDialogButtonBox.StandardButton.Yes
         )
         button_box.accepted.connect(self.accept)
         button_box.rejected.connect(self.reject)
@@ -251,7 +253,7 @@ You can disable this at any time in the Exception Log Window.
 
 def _show_send_errors_dialog() -> bool | None:
     """Show a dialog to ask the user if they want to send error reports."""
-    dlg = SendErrorsDialog()
+    dlg = OptInDialog()
     dlg.exec()
     if dlg.result() < 0:
         return None

--- a/src/pymmcore_gui/_sentry.py
+++ b/src/pymmcore_gui/_sentry.py
@@ -216,7 +216,7 @@ Please help us fix bugs by allowing us to collect crash and exception reports.
 <li>We collect tracebacks that show where errors occur.</li>
 <li>We collect program, and python versions.</li>
 <li>Error-reporting logic is viewable in the
-<a href="https://github.com/pymmcore-plus/pymmcore-gui/blob/main/src/pymmcore_gui/_utils.py">
+<a href="https://github.com/pymmcore-plus/pymmcore-gui/blob/main/src/pymmcore_gui/_sentry.py">
 source code</a>.</li>
 </ul>
 

--- a/src/pymmcore_gui/_sentry.py
+++ b/src/pymmcore_gui/_sentry.py
@@ -132,6 +132,16 @@ def install_error_reporter() -> None:  # pragma: no cover
     if "PYTEST_VERSION" in os.environ:
         return
 
+    try:
+        import sentry_sdk
+    except ImportError:
+        logger.debug("sentry-sdk not installed, skipping error reporting.")
+        return
+
+    global SENTRY_INSTALLED
+    if SENTRY_INSTALLED:
+        return
+
     # ask the user if it's ok
     settings = Settings.instance()
     if settings.send_error_reports is None:
@@ -145,16 +155,7 @@ def install_error_reporter() -> None:  # pragma: no cover
         logger.debug("Error reporting disabled by user.")
         return
 
-    try:
-        import sentry_sdk
-    except ImportError:
-        logger.debug("sentry-sdk not installed, skipping error reporting.")
-        return
-
-    global SENTRY_INSTALLED
-    if SENTRY_INSTALLED:
-        return
-
+    logger.debug("Error reporting enabled by user.")
     sentry_sdk.init(
         SENTRY_DSN,
         # When enabled, local variables are sent along with stackframes.

--- a/src/pymmcore_gui/_settings.py
+++ b/src/pymmcore_gui/_settings.py
@@ -125,6 +125,8 @@ class SettingsV1(BaseMMSettings):
 
     version: Literal["1.0"] = "1.0"
     window: WindowSettingsV1 = Field(default_factory=WindowSettingsV1)
+    # None means the user has neither opted in nor out
+    send_error_reports: bool | None = None
     last_config: Path | None = None
 
     @property
@@ -198,3 +200,12 @@ class SettingsV1(BaseMMSettings):
 
 Settings = SettingsV1
 _GLOBAL_SETTINGS = SettingsV1()
+
+
+def reset_to_defaults() -> None:
+    """Erase user settings and reset to defaults."""
+    global _GLOBAL_SETTINGS
+    if TESTING or os.getenv("MMGUI_NO_SETTINGS"):  # pragma: no cover
+        return
+    SETTINGS_FILE_NAME.unlink(missing_ok=True)
+    _GLOBAL_SETTINGS = SettingsV1()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 
-from pymmcore_gui.settings import Settings
+from pymmcore_gui._settings import Settings
 
 # This is a temporary fix due to a `DeprecationWarning` from the `qtconsole` package:
 # """DeprecationWarning: Jupyter is migrating its paths to use standard platformdirs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,7 +52,7 @@ def mmcore() -> Iterator[CMMCorePlus]:
 @pytest.fixture(autouse=True)
 def settings() -> Iterator[Settings]:
     settings = Settings()
-    with patch("pymmcore_gui.settings._GLOBAL_SETTINGS", settings):
+    with patch("pymmcore_gui._settings._GLOBAL_SETTINGS", settings):
         yield settings
 
 

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from PyQt6Ads import CDockAreaWidget
     from pytestqt.qtbot import QtBot
 
-    from pymmcore_gui.settings import Settings
+    from pymmcore_gui._settings import Settings
 
 
 @pytest.mark.parametrize("w_action", list(WidgetAction))

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 from pydantic_settings import BaseSettings
 
-from pymmcore_gui.settings import MMGuiUserPrefsSource, SettingsV1
+from pymmcore_gui._settings import MMGuiUserPrefsSource, SettingsV1
 
 
 def test_settings() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1367,6 +1367,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "qtconsole" },
     { name = "rich" },
+    { name = "sentry-sdk" },
     { name = "superqt", extra = ["cmap", "iconify"] },
     { name = "tifffile" },
     { name = "tqdm" },
@@ -1403,6 +1404,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "qtconsole", specifier = ">=5.6.1" },
     { name = "rich" },
+    { name = "sentry-sdk", specifier = ">=2.20.0" },
     { name = "superqt", extras = ["cmap", "iconify"], specifier = ">=0.7.1" },
     { name = "tifffile", specifier = ">=2024.12.12" },
     { name = "tqdm", specifier = ">=4.67.1" },
@@ -1975,6 +1977,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/e8/4ba3b2405db0864f9ea5cee2aaa7c057d5ee6c122e996428e9c2b749ddf0/rust_just-1.38.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:c626588d64b5fd39bbe5072c6ddd0e0f443b1682a4143be45429046f42be66e3", size = 1938453 },
     { url = "https://files.pythonhosted.org/packages/23/17/0f10aca56132d47e085c33a46d4a016a08ec081cd9efb8e55953ddc2067e/rust_just-1.38.0-py3-none-win32.whl", hash = "sha256:bcbaa423988d94218a457f44aa1310e959a2e634a93147d70cb9940b6a687a5d", size = 1559911 },
     { url = "https://files.pythonhosted.org/packages/a1/78/0a8b305c9fcd16a639ad6dd56268c642828769cd736041d554c82dc135ea/rust_just-1.38.0-py3-none-win_amd64.whl", hash = "sha256:2590b0a3eed6090129a618b7cbd94e107407b618eef95baba8c596fcf598f7a7", size = 1679295 },
+]
+
+[[package]]
+name = "sentry-sdk"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/e8/6a366c0cd5e129dda6ecb20ff097f70b18182c248d4c27e813c21f98992a/sentry_sdk-2.20.0.tar.gz", hash = "sha256:afa82713a92facf847df3c6f63cec71eb488d826a50965def3d7722aa6f0fdab", size = 300125 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/0f/6f7e6cd0f4a141752caef3f79300148422fdf2b8b68b531f30b2b0c0cbda/sentry_sdk-2.20.0-py2.py3-none-any.whl", hash = "sha256:c359a1edf950eb5e80cffd7d9111f3dbeef57994cb4415df37d39fda2cf22364", size = 322576 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2066,15 +2066,15 @@ wheels = [
 
 [[package]]
 name = "sentry-sdk"
-version = "2.20.0"
+version = "2.26.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/68/e8/6a366c0cd5e129dda6ecb20ff097f70b18182c248d4c27e813c21f98992a/sentry_sdk-2.20.0.tar.gz", hash = "sha256:afa82713a92facf847df3c6f63cec71eb488d826a50965def3d7722aa6f0fdab", size = 300125 }
+sdist = { url = "https://files.pythonhosted.org/packages/85/26/099631caa51abffb1fd9e08c2138bc6681d3f288a5936c2fc4e054729611/sentry_sdk-2.26.1.tar.gz", hash = "sha256:759e019c41551a21519a95e6cef6d91fb4af1054761923dadaee2e6eca9c02c7", size = 323099 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/0f/6f7e6cd0f4a141752caef3f79300148422fdf2b8b68b531f30b2b0c0cbda/sentry_sdk-2.20.0-py2.py3-none-any.whl", hash = "sha256:c359a1edf950eb5e80cffd7d9111f3dbeef57994cb4415df37d39fda2cf22364", size = 322576 },
+    { url = "https://files.pythonhosted.org/packages/23/32/0a30b4fafdb3d26d133f99bb566aaa6000004ee7f2c4b72aafea9237ab7e/sentry_sdk-2.26.1-py2.py3-none-any.whl", hash = "sha256:e99390e3f217d13ddcbaeaed08789f1ca614d663b345b9da42e35ad6b60d696a", size = 340558 },
 ]
 
 [[package]]


### PR DESCRIPTION
This adds opt-in error reporting via sentry.io

If a user hasn't made a choice, they are presented with this dialog:

<img width="612" alt="Screenshot 2025-04-15 at 7 49 15 PM" src="https://github.com/user-attachments/assets/8113cba8-d832-4828-984e-41716b22c79a" />

and can later opt in/out via the exceptions log:

<img width="490" alt="Screenshot 2025-04-15 at 7 49 29 PM" src="https://github.com/user-attachments/assets/dfc4b365-6f59-4b41-b062-f7389988668c" />

on sentry, this is what we see:

<img width="1070" alt="image" src="https://github.com/user-attachments/assets/1fec1089-69d8-46fa-8015-610699672fea" />

<img width="1194" alt="image" src="https://github.com/user-attachments/assets/a8fe57f2-1f74-4324-a105-32ade4959418" />
