### PR TITLE
refactor: remove _app.main() return value

### DIFF
--- a/src/pymmcore_gui/_app.py
+++ b/src/pymmcore_gui/_app.py
@@ -74,7 +74,7 @@ def parse_args(args: Sequence[str] = ()) -> argparse.Namespace:
     return parser.parse_args(args)
 
 
-def main() -> QCoreApplication:
+def main() -> None:
     """Run the Micro-Manager GUI."""
     args = parse_args()
 
@@ -111,14 +111,6 @@ def main() -> QCoreApplication:
         pyi_splash.close()
 
     app.exec()
-
-    # NOTE:
-    # the fact that we're returning the app instance after exec() is a little odd.
-    # it's there for testing so that `test_app::test_main_app` can retain a reference
-    # to the application for the scope of the test.
-    # I also tried retaining a global app reference within this module, but that led
-    # to consistent segfaults for reasons I don't understand.
-    return app
 
 
 # ------------------- Custom excepthook -------------------

--- a/src/pymmcore_gui/_app.py
+++ b/src/pymmcore_gui/_app.py
@@ -10,7 +10,7 @@ import warnings
 from contextlib import suppress
 from typing import TYPE_CHECKING, cast
 
-from PyQt6.QtCore import QCoreApplication, QTimer, pyqtSignal
+from PyQt6.QtCore import QTimer, pyqtSignal
 from PyQt6.QtGui import QIcon
 from PyQt6.QtWidgets import QApplication
 from superqt.utils import WorkerBase

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -12,7 +12,7 @@ def test_main_app(monkeypatch: MonkeyPatch) -> None:
         _app.MMQApplication, "exec", lambda _: QApplication.processEvents()
     ):
         monkeypatch.setattr(sys, "argv", ["mmgui"])
-        _ = _app.main()  # must retain handle for scope of this test.
+        _app.main()
 
         assert QApplication.instance()
         assert isinstance(QApplication.instance(), _app.MMQApplication)


### PR DESCRIPTION
this removes a weird hack that I didn't understand in the first place, and appears to be no longer needed