### PR TITLE
feature: remember last configuration, add autoload option

### DIFF
--- a/src/pymmcore_gui/_app.py
+++ b/src/pymmcore_gui/_app.py
@@ -12,7 +12,12 @@ from typing import TYPE_CHECKING, cast
 
 from PyQt6.QtCore import QTimer, pyqtSignal
 from PyQt6.QtGui import QIcon
-from PyQt6.QtWidgets import QApplication, QMessageBox
+from PyQt6.QtWidgets import (
+    QApplication,
+    QCheckBox,
+    QMessageBox,
+    QWidget,
+)
 from superqt.utils import WorkerBase
 
 from pymmcore_gui import __version__
@@ -23,6 +28,7 @@ from . import _sentry
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from pathlib import Path
     from types import TracebackType
 
     ExcTuple = tuple[type[BaseException], BaseException, TracebackType | None]
@@ -110,29 +116,11 @@ def main() -> None:
     win = MicroManagerGUI()
     QTimer.singleShot(0, lambda: win._restore_state(True))
 
-    # FIXME: be better...
-    try:
-        settings = Settings.instance()
-        if args.config:
-            win.mmcore.loadSystemConfiguration(args.config)
-        elif last_config := settings.last_config:
-            if settings.auto_load_last_config:
-                win.mmcore.loadSystemConfiguration(last_config)
-            else:
-                # show dialog to ask if the user wants to load the last config
-                response = QMessageBox.question(
-                    win,
-                    "Load last config?",
-                    f"Do you want to load the last-used config file:\n\n{last_config}?",
-                    QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
-                    QMessageBox.StandardButton.Yes,
-                )
-                if response == QMessageBox.StandardButton.Yes:
-                    win.mmcore.loadSystemConfiguration(last_config)
-        else:
-            win.mmcore.loadSystemConfiguration()
-    except Exception as e:
-        print(f"Failed to load system configuration: {e}")
+    if config := _decide_configuration(args.config, win):
+        try:
+            win.mmcore.loadSystemConfiguration(config)
+        except Exception as e:
+            print(f"Failed to load system configuration: {e}")
 
     splsh = "_PYI_SPLASH_IPC" in os.environ and importlib.util.find_spec("pyi_splash")
     if splsh:  # pragma: no cover
@@ -143,6 +131,50 @@ def main() -> None:
 
     _sentry.install_error_reporter()
     app.exec()
+
+
+def _decide_configuration(
+    config: str | None = None, parent: QWidget | None = None
+) -> str | None:
+    settings = Settings.instance()
+    if config:
+        return config
+
+    if last_config := settings.last_config:
+        if auto_load := settings.auto_load_last_config:
+            return str(last_config)
+
+        # show dialog to ask if the user wants to load the last config
+        if auto_load is None:
+            dialog = LoadConfigDialog(last_config)
+            if (btn := dialog.exec()) != QMessageBox.StandardButton.Cancel:
+                auto_load = btn == QMessageBox.StandardButton.Yes
+                if dialog.dont_ask_again.isChecked():
+                    settings.auto_load_last_config = auto_load
+                    settings.flush()
+                if auto_load:
+                    return str(last_config)
+
+    if settings.fallback_to_demo_config:
+        return "MMConfig_demo.cfg"
+    return None
+
+
+class LoadConfigDialog(QMessageBox):
+    def __init__(self, last_config: Path | str):
+        super().__init__(
+            QMessageBox.Icon.Question,
+            "Load last config?",
+            f"Do you want to load the last-used config file:\n\n{last_config}?",
+            QMessageBox.StandardButton.Yes
+            | QMessageBox.StandardButton.No
+            | QMessageBox.StandardButton.Cancel,
+        )
+        self.setDefaultButton(QMessageBox.StandardButton.Yes)
+        self.setEscapeButton(QMessageBox.StandardButton.Cancel)
+
+        self.dont_ask_again = QCheckBox("Don't ask again")
+        self.setCheckBox(self.dont_ask_again)
 
 
 # ------------------- Custom excepthook -------------------

--- a/src/pymmcore_gui/_main_window.py
+++ b/src/pymmcore_gui/_main_window.py
@@ -152,6 +152,9 @@ class MicroManagerGUI(QMainWindow):
 
         # get global CMMCorePlus instance
         self._mmc = mmcore or CMMCorePlus.instance()
+        self._mmc.events.systemConfigurationLoaded.connect(
+            self._on_system_config_loaded
+        )
 
         self._img_preview = ImagePreview(self, mmcore=self._mmc)
         self._img_preview.setObjectName("ImagePreview")

--- a/src/pymmcore_gui/_main_window.py
+++ b/src/pymmcore_gui/_main_window.py
@@ -76,6 +76,7 @@ class Menu(str, Enum):
 
     PYMM_GUI = "pymmcore-gui"
     WINDOW = "Window"
+    HELP = "Help"
 
     def __str__(self) -> str:
         return str(self.value)
@@ -132,6 +133,7 @@ class MicroManagerGUI(QMainWindow):
             WidgetAction.EXCEPTION_LOG,
             WidgetAction.CONFIG_WIZARD,
         ],
+        Menu.HELP: [CoreAction.LOAD_DEMO],
     }
 
     def __init__(self, *, mmcore: CMMCorePlus | None = None) -> None:

--- a/src/pymmcore_gui/_settings.py
+++ b/src/pymmcore_gui/_settings.py
@@ -127,6 +127,7 @@ class SettingsV1(BaseMMSettings):
     window: WindowSettingsV1 = Field(default_factory=WindowSettingsV1)
     # None means the user has neither opted in nor out
     send_error_reports: bool | None = None
+    auto_load_last_config: bool = False
     last_config: Path | None = None
 
     @property

--- a/src/pymmcore_gui/_settings.py
+++ b/src/pymmcore_gui/_settings.py
@@ -125,10 +125,16 @@ class SettingsV1(BaseMMSettings):
 
     version: Literal["1.0"] = "1.0"
     window: WindowSettingsV1 = Field(default_factory=WindowSettingsV1)
-    # None means the user has neither opted in nor out
+
     send_error_reports: bool | None = None
-    auto_load_last_config: bool = False
+    """Whether to send error reports to the developers, None means undecided."""
+
     last_config: Path | None = None
+    """Path to the last used config file."""
+    auto_load_last_config: bool | None = None
+    """Load the last used config on startup. None means undecided."""
+    fallback_to_demo_config: bool = False
+    """Load demo config if no config is found."""
 
     @property
     def version_tuple(self) -> tuple[int, int, str]:

--- a/src/pymmcore_gui/actions/core_actions.py
+++ b/src/pymmcore_gui/actions/core_actions.py
@@ -15,6 +15,7 @@ class CoreAction(ActionKey):
 
     SNAP = "Snap Image"
     TOGGLE_LIVE = "Toggle Live"
+    LOAD_DEMO = "Load Demo Configuration"
 
 
 # ######################## Functions acting on the Core #########################
@@ -50,6 +51,11 @@ def _init_toggle_live(action: QCoreAction) -> None:
     mmc.events.sequenceAcquisitionStopped.connect(_on_change)
 
 
+def load_demo_config(action: QCoreAction, checked: bool) -> None:
+    """Load the demo configuration."""
+    action.mmc.loadSystemConfiguration()
+
+
 # ########################## Action Info Instances #############################
 
 snap_action = ActionInfo(
@@ -69,4 +75,9 @@ toggle_live_action = ActionInfo(
     checkable=True,
     on_triggered=toggle_live,
     on_created=_init_toggle_live,
+)
+
+load_demo_action = ActionInfo(
+    key=CoreAction.LOAD_DEMO,
+    on_triggered=load_demo_config,
 )


### PR DESCRIPTION
This PR actually uses the `Settings.last_config` option if it is in the settings.  It shows a dialog asking the user if they want to use the last config.  Checking the box will save and never ask again.

<img width="420" alt="Screenshot 2025-04-23 at 2 55 16 PM" src="https://github.com/user-attachments/assets/44a5346b-300c-4c2a-a9cd-16104078a4d3" />

This means we don *not* fallback to the demo config. so there is a new convenience in the Help menu