### PR TITLE
feat: Enable contribution of widgets and (other actions) by declaring `[Widget]ActionInfo`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+.vscode/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,8 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "BSD-3-Clause" }
 authors = [
-    { email = "federico.gasparoli@gmail.com", name = "Federico Gasparoli" },
     { name = "Talley Lambert", email = "talley.lambert@gmail.com" },
+    { name = "Federico Gasparoli", email = "federico.gasparoli@gmail.com" },
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -62,16 +62,21 @@ dependencies = [
 # override-dependencies = ["pymmcore ;  sys_platform == 'never'"]
 
 [dependency-groups]
-dev = [
-    "ipython>=8.30.0",
-    "mypy>=1.13.0",
-    "pre-commit>=4.0.1",
-    "pyautogui>=0.9.54",
-    "pyinstaller>=6.11.1",
-    "pyright>=1.1.392.post0",
+test = [
     "pytest>=8.3.4",
     "pytest-cov>=6.0.0",
     "pytest-qt>=4.4.0",
+    "pyautogui>=0.9.54",
+    "pytest-order>=1.3.0",
+]
+dev = [
+    { include-group = "test" },
+    "diff-cover>=9.2.4",
+    "ipython>=8.30.0",
+    "mypy>=1.13.0",
+    "pre-commit>=4.0.1",
+    "pyinstaller>=6.11.1",
+    "pyright>=1.1.392.post0",
     "rich>=13.9.4",
     "ruff>=0.8.3",
     "rust-just>=1.38.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ select = [
     "B",    # flake8-bugbear
     "A001", # flake8-builtins
     "RUF",  # ruff-specific rules
+    "T100", # no breakpoints
     "TC",   # flake8-type-checking
     "TID",  # flake8-tidy-imports
 ]

--- a/src/pymmcore_gui/_app.py
+++ b/src/pymmcore_gui/_app.py
@@ -119,7 +119,7 @@ def create_mmgui(
         elif config := _decide_configuration(mm_config, win):
             try:
                 win.mmcore.loadSystemConfiguration(config)
-            except Exception as e:
+            except Exception as e:  # pragma: no cover
                 warnings.warn(
                     f"Failed to load system configuration: {e}",
                     RuntimeWarning,
@@ -279,7 +279,7 @@ def ndv_excepthook(
                 additional_info.is_tracing -= 1
     # otherwise, if MMGUI_DEBUG_EXCEPTIONS is set, drop into pdb
     elif os.getenv("MMGUI_DEBUG_EXCEPTIONS"):
-        import pdb
+        import pdb  # noqa: T100
 
         pdb.post_mortem(tb)
 

--- a/src/pymmcore_gui/_app.py
+++ b/src/pymmcore_gui/_app.py
@@ -102,6 +102,7 @@ def create_mmgui(
         warnings.warn(
             "A QApplication instance already exists, but it is not MMQApplication. "
             " This may cause unexpected behavior.",
+            RuntimeWarning,
             stacklevel=2,
         )
 
@@ -119,7 +120,11 @@ def create_mmgui(
             try:
                 win.mmcore.loadSystemConfiguration(config)
             except Exception as e:
-                print(f"Failed to load system configuration: {e}")
+                warnings.warn(
+                    f"Failed to load system configuration: {e}",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
 
     if install_sys_excepthook:
         _install_excepthook()

--- a/src/pymmcore_gui/_main_window.py
+++ b/src/pymmcore_gui/_main_window.py
@@ -94,8 +94,17 @@ class Toolbar(str, Enum):
         return str(self.value)
 
 
-ToolDictValue = list[str] | Callable[[CMMCorePlus, QMainWindow], QToolBar]
-MenuDictValue = list[str] | Callable[[CMMCorePlus, QMainWindow], QMenu]
+ToolDictValue = list[str] | Callable[[CMMCorePlus, "MicroManagerGUI"], QToolBar]
+MenuDictValue = list[str] | Callable[[CMMCorePlus, "MicroManagerGUI"], QMenu]
+
+
+def _create_window_menu(mmc: CMMCorePlus, parent: MicroManagerGUI) -> QMenu:
+    """Create the Window menu."""
+    menu = QMenu(Menu.WINDOW.value, parent)
+    actions = sorted(ActionInfo.widget_actions())
+    for action in actions:
+        menu.addAction(parent.get_action(action))
+    return menu
 
 
 class MicroManagerGUI(QMainWindow):
@@ -122,7 +131,7 @@ class MicroManagerGUI(QMainWindow):
     # that takes a CMMCorePlus instance and QMainWindow and returns a QMenu.
     MENUS: Mapping[str, MenuDictValue] = {
         Menu.PYMM_GUI: [WidgetAction.ABOUT],
-        Menu.WINDOW: [],
+        Menu.WINDOW: _create_window_menu,
         Menu.HELP: [CoreAction.LOAD_DEMO],
     }
 
@@ -172,8 +181,6 @@ class MicroManagerGUI(QMainWindow):
         # To add menus or menu items, add them to the MENUS dict above
 
         for name, entry in self.MENUS.items():
-            if name == Menu.WINDOW:
-                entry = sorted(ActionInfo.widget_actions())
             self._add_menubar(name, entry)
 
         # TOOLBARS =================================

--- a/src/pymmcore_gui/_main_window.py
+++ b/src/pymmcore_gui/_main_window.py
@@ -10,7 +10,7 @@ from weakref import WeakValueDictionary
 
 from pymmcore_plus import CMMCorePlus
 from pymmcore_widgets import ConfigWizard
-from PyQt6.QtCore import Qt, QTimer
+from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QAction, QCloseEvent, QGuiApplication, QIcon
 from PyQt6.QtWidgets import (
     QApplication,
@@ -209,7 +209,7 @@ class MicroManagerGUI(QMainWindow):
         self._central.setWidget(self._img_preview)
         self._central_dock_area = self.dock_manager.setCentralWidget(self._central)
 
-        QTimer.singleShot(0, self._restore_state)
+        # QTimer.singleShot(0, self._restore_state)
 
     # --------------------- Properties ----------------------
 
@@ -408,8 +408,10 @@ class MicroManagerGUI(QMainWindow):
         for key in initial_widgets:
             try:
                 self.get_widget(key)
-            except KeyError as e:
-                self.nm.show_error_message(str(e))
+            except KeyError:
+                self.nm.show_warning_message(
+                    f"Unable to reload widget key stored in settings: {key!r}",
+                )
 
         # restore position and size of the main window
         if geo := settings.window.geometry:
@@ -434,6 +436,7 @@ class MicroManagerGUI(QMainWindow):
 
         if show:
             self.show()
+            self.nm.reposition_notifications()
 
     def _save_state(self) -> None:
         """Save the state of the window to settings."""

--- a/src/pymmcore_gui/_main_window.py
+++ b/src/pymmcore_gui/_main_window.py
@@ -399,22 +399,7 @@ class MicroManagerGUI(QMainWindow):
         initial_widgets = settings.window.initial_widgets
         # we need to create the widgets first, before calling restoreState.
         for key in initial_widgets:
-            try:
-                self.get_widget(key)
-            except KeyError:
-                # Find possible matches among available widget actions
-                import difflib
-
-                if matches := difflib.get_close_matches(
-                    key, list(ActionInfo._registry), n=1, cutoff=0.5
-                ):
-                    suggestion = f"\nDid you mean: {matches[0]}?"
-                else:
-                    suggestion = ""
-                self.nm.show_warning_message(
-                    "Cannot find info for widget that was saved in the settings with "
-                    f"key: {key!r}.{suggestion}",
-                )
+            self.get_widget(key)
 
         # restore position and size of the main window
         if geo := settings.window.geometry:

--- a/src/pymmcore_gui/_main_window.py
+++ b/src/pymmcore_gui/_main_window.py
@@ -33,7 +33,7 @@ from ._ndv_viewers import NDVViewersManager
 from ._notification_manager import NotificationManager
 from ._settings import Settings
 from .actions import CoreAction, WidgetAction
-from .actions._action_info import ActionKey
+from .actions._action_info import ActionInfo
 
 try:
     from .widgets._pygfx_image import PygfxImagePreview as ImagePreview
@@ -94,8 +94,8 @@ class Toolbar(str, Enum):
         return str(self.value)
 
 
-ToolDictValue = list[ActionKey] | Callable[[CMMCorePlus, QMainWindow], QToolBar]
-MenuDictValue = list[ActionKey] | Callable[[CMMCorePlus, QMainWindow], QMenu]
+ToolDictValue = list[str] | Callable[[CMMCorePlus, QMainWindow], QToolBar]
+MenuDictValue = list[str] | Callable[[CMMCorePlus, QMainWindow], QMenu]
 
 
 class MicroManagerGUI(QMainWindow):
@@ -122,17 +122,7 @@ class MicroManagerGUI(QMainWindow):
     # that takes a CMMCorePlus instance and QMainWindow and returns a QMenu.
     MENUS: Mapping[str, MenuDictValue] = {
         Menu.PYMM_GUI: [WidgetAction.ABOUT],
-        Menu.WINDOW: [
-            WidgetAction.CONSOLE,
-            WidgetAction.PROP_BROWSER,
-            WidgetAction.INSTALL_DEVICES,
-            WidgetAction.MDA_WIDGET,
-            WidgetAction.STAGE_CONTROL,
-            WidgetAction.CAMERA_ROI,
-            WidgetAction.CONFIG_GROUPS,
-            WidgetAction.EXCEPTION_LOG,
-            WidgetAction.CONFIG_WIZARD,
-        ],
+        Menu.WINDOW: [],
         Menu.HELP: [CoreAction.LOAD_DEMO],
     }
 
@@ -146,11 +136,11 @@ class MicroManagerGUI(QMainWindow):
         # when the same action is requested multiple times. This is useful to
         # synchronize the state of actions that may appear in multiple menus or
         # toolbars.
-        self._qactions = WeakValueDictionary[ActionKey, QAction]()
+        self._qactions = WeakValueDictionary[str, QAction]()
         # widgets that are associated with a QAction
-        self._action_widgets = WeakValueDictionary[WidgetAction, QWidget]()
+        self._action_widgets = WeakValueDictionary[str, QWidget]()
         # the wrapping QDockWidget for widgets that are associated with a QAction
-        self._dock_widgets = WeakValueDictionary[WidgetAction, CDockWidget]()
+        self._dock_widgets = WeakValueDictionary[str, CDockWidget]()
 
         # get global CMMCorePlus instance
         self._mmc = mmcore or CMMCorePlus.instance()
@@ -182,6 +172,8 @@ class MicroManagerGUI(QMainWindow):
         # To add menus or menu items, add them to the MENUS dict above
 
         for name, entry in self.MENUS.items():
+            if name == Menu.WINDOW:
+                entry = sorted(ActionInfo.widget_actions())
             self._add_menubar(name, entry)
 
         # TOOLBARS =================================
@@ -226,7 +218,7 @@ class MicroManagerGUI(QMainWindow):
     # --------------------- Public methods ----------------------
     # -----------------------------------------------------------
 
-    def get_action(self, key: ActionKey, create: bool = True) -> QAction:
+    def get_action(self, key: str, create: bool = True) -> QAction:
         """Create a QAction from this key."""
         if key not in self._qactions:
             if not create:  # pragma: no cover
@@ -234,10 +226,10 @@ class MicroManagerGUI(QMainWindow):
                     f"Action {key} has not been created yet, and 'create' is False"
                 )
             # create and cache it
-            info: WidgetActionInfo[QWidget] = WidgetActionInfo.for_key(key)
+            info = ActionInfo.for_key(key)
             self._qactions[key] = action = info.to_qaction(self._mmc, self)
             # connect WidgetActions to toggle their widgets
-            if isinstance(action.key, WidgetAction):
+            if isinstance(info, WidgetActionInfo):
                 action.triggered.connect(self._toggle_action_widget)
 
         return self._qactions[key]
@@ -269,9 +261,9 @@ class MicroManagerGUI(QMainWindow):
     def get_widget(self, key: Literal[WidgetAction.STAGE_CONTROL], create: bool = ...) -> StagesControlWidget: ...  # noqa: E501
     # generic fallback
     @overload
-    def get_widget(self, key: WidgetAction, create: bool = ...) -> QWidget: ...
+    def get_widget(self, key: str, create: bool = ...) -> QWidget: ...
     # fmt: on
-    def get_widget(self, key: WidgetAction, create: bool = True) -> QWidget:
+    def get_widget(self, key: str, create: bool = True) -> QWidget:
         """Get (or create) widget for `key` ensuring that it is linked to its QAction.
 
         If the widget has been "closed" (hidden), it will be re-shown.
@@ -291,14 +283,16 @@ class MicroManagerGUI(QMainWindow):
         KeyError
             If the widget doesn't exist and `create` is False.
         """
+        print("get_widget", key)
         if key not in self._action_widgets:
             if not create:  # pragma: no cover
                 raise KeyError(
                     f"Widget {key} has not been created yet, and 'create' is False"
                 )
-            area = key.dock_area()
-            widget = key.create_widget(self)
-            widget.setObjectName(key.name)
+            info: WidgetActionInfo = WidgetActionInfo.for_key(key)
+            area = info.dock_area
+            widget = info.create_widget(self)
+            widget.setObjectName(info.key)
             if isinstance(widget, QDialog):
                 widget.exec()
                 return widget
@@ -306,9 +300,9 @@ class MicroManagerGUI(QMainWindow):
             self._action_widgets[key] = widget
 
             action = self.get_action(key)
-            dock = CDockWidget(key.value, self)
-            dock.setWidget(widget, key.scroll_mode())
-            dock.setObjectName(f"docked_{key.name}")
+            dock = CDockWidget(info.text, self)
+            dock.setWidget(widget, info.scroll_mode)
+            dock.setObjectName(f"docked_{info.key}")
             dock.setToggleViewAction(action)
             dock.setMinimumSize(widget.minimumSize())
             dock.setIcon(action.icon())
@@ -335,7 +329,7 @@ class MicroManagerGUI(QMainWindow):
 
         return self._action_widgets[key]
 
-    def get_dock_widget(self, key: WidgetAction) -> CDockWidget:
+    def get_dock_widget(self, key: str) -> CDockWidget:
         """Get the QDockWidget for `key`.
 
         Note, you can also get the QDockWidget by calling `get_widget(key)`, and then
@@ -389,6 +383,7 @@ class MicroManagerGUI(QMainWindow):
         else:
             menu = cast("QMenu", mb.addMenu(name))
             for action in menu_entry:
+                print("Adding action", action)
                 menu.addAction(self.get_action(action))
 
     def closeEvent(self, a0: QCloseEvent | None) -> None:
@@ -449,7 +444,7 @@ class MicroManagerGUI(QMainWindow):
         # write to disk, blocking up to 5 seconds
         settings.flush(timeout=5000)
 
-    def _open_widgets(self) -> set[WidgetAction]:
+    def _open_widgets(self) -> set[str]:
         """Return the set of open widgets."""
         return {
             key
@@ -464,20 +459,19 @@ class MicroManagerGUI(QMainWindow):
         `get_action`, so it is assumed that the sender is a QCoreAction with a
         WidgetAction key.  Calling otherwise will do nothing.
         """
-        if not (
-            isinstance(action := self.sender(), QCoreAction)
-            and isinstance((key := action.key), WidgetAction)
-        ):
+        if not (isinstance(action := self.sender(), QCoreAction)):
             return
 
         # if the widget is a dock widget, we want to toggle the dock widget
         # rather than the inner widget
-        if key in self._dock_widgets:
-            widget: QWidget = self.get_dock_widget(key)
+        if action.key in self._dock_widgets:
+            print("Dock widget", action.key)
+            widget: QWidget = self.get_dock_widget(action.key)
         else:
+            print("get widget", action.key)
             # this will create the widget if it doesn't exist yet,
             # e.g. for a click event on a Toolbutton that doesn't yet have a widget
-            widget = self.get_widget(key)
+            widget = self.get_widget(action.key)
         widget.setVisible(checked)
         if checked:
             widget.raise_()

--- a/src/pymmcore_gui/_main_window.py
+++ b/src/pymmcore_gui/_main_window.py
@@ -10,7 +10,7 @@ from weakref import WeakValueDictionary
 
 from pymmcore_plus import CMMCorePlus
 from pymmcore_widgets import ConfigWizard
-from PyQt6.QtCore import Qt
+from PyQt6.QtCore import Qt, QTimer
 from PyQt6.QtGui import QAction, QCloseEvent, QGuiApplication, QIcon
 from PyQt6.QtWidgets import (
     QApplication,
@@ -209,7 +209,7 @@ class MicroManagerGUI(QMainWindow):
         self._central.setWidget(self._img_preview)
         self._central_dock_area = self.dock_manager.setCentralWidget(self._central)
 
-        # QTimer.singleShot(0, self._restore_state)
+        QTimer.singleShot(0, self._restore_state)
 
     # --------------------- Properties ----------------------
 

--- a/src/pymmcore_gui/_main_window.py
+++ b/src/pymmcore_gui/_main_window.py
@@ -26,8 +26,8 @@ from PyQt6.QtWidgets import (
 from PyQt6Ads import CDockManager, CDockWidget, SideBarLocation
 from superqt import QIconifyIcon
 
+from pymmcore_gui.actions._action_info import WidgetActionInfo
 from pymmcore_gui.actions._core_qaction import QCoreAction
-from pymmcore_gui.actions.widget_actions import WidgetActionInfo
 
 from ._ndv_viewers import NDVViewersManager
 from ._notification_manager import NotificationManager
@@ -399,7 +399,10 @@ class MicroManagerGUI(QMainWindow):
         initial_widgets = settings.window.initial_widgets
         # we need to create the widgets first, before calling restoreState.
         for key in initial_widgets:
-            self.get_widget(key)
+            try:
+                self.get_widget(key)
+            except KeyError as e:
+                self.nm.show_error_message(str(e))
 
         # restore position and size of the main window
         if geo := settings.window.geometry:

--- a/src/pymmcore_gui/_settings.py
+++ b/src/pymmcore_gui/_settings.py
@@ -93,13 +93,13 @@ class MMGuiUserPrefsSource(PydanticBaseSettingsSource):
         return None, "", False  # pragma: no cover
 
 
-def _default_widgets() -> set[WidgetAction]:
+def _default_widgets() -> set[str]:
     """The default set widgets that open on launch."""
     return {WidgetAction.CONFIG_GROUPS, WidgetAction.MDA_WIDGET}
 
 
 # set of widgets that are sorted when serialized
-InitialWidgets = Annotated[set[WidgetAction], WrapSerializer(lambda v, h: sorted(h(v)))]
+InitialWidgets = Annotated[set[str], WrapSerializer(lambda v, h: sorted(h(v)))]
 
 
 class WindowSettingsV1(BaseMMSettings):

--- a/src/pymmcore_gui/actions/__init__.py
+++ b/src/pymmcore_gui/actions/__init__.py
@@ -3,13 +3,14 @@
 from . import core_actions, widget_actions
 from ._action_info import ActionInfo, ActionKey
 from .core_actions import CoreAction
-from .widget_actions import WidgetAction
+from .widget_actions import WidgetAction, WidgetActionInfo
 
 __all__ = [
     "ActionInfo",
     "ActionKey",
     "CoreAction",
     "WidgetAction",
+    "WidgetActionInfo",
     "core_actions",
     "widget_actions",
 ]

--- a/src/pymmcore_gui/actions/__init__.py
+++ b/src/pymmcore_gui/actions/__init__.py
@@ -1,16 +1,15 @@
 # these MUST be imported here in order to actually instantiate the actions
 # and register them with the ActionInfo registry
-from . import core_actions, widget_actions
-from ._action_info import ActionInfo, ActionKey
+from ._action_info import ActionInfo, ActionKey, WidgetActionInfo
+from ._core_qaction import QCoreAction
 from .core_actions import CoreAction
-from .widget_actions import WidgetAction, WidgetActionInfo
+from .widget_actions import WidgetAction
 
 __all__ = [
     "ActionInfo",
     "ActionKey",
     "CoreAction",
+    "QCoreAction",
     "WidgetAction",
     "WidgetActionInfo",
-    "core_actions",
-    "widget_actions",
 ]

--- a/src/pymmcore_gui/actions/_action_info.py
+++ b/src/pymmcore_gui/actions/_action_info.py
@@ -106,7 +106,7 @@ class ActionInfo(BaseModel):
             if matches := difflib.get_close_matches(
                 key, list(ActionInfo._registry), n=1, cutoff=0.5
             ):
-                suggestion = f"\nDid you mean: {matches[0]}?"
+                suggestion = f"\nDid you mean {matches[0]!r}?"
 
             raise KeyError(
                 f"No 'ActionInfo' has been declared for key '{key}'.{suggestion}"

--- a/src/pymmcore_gui/actions/_action_info.py
+++ b/src/pymmcore_gui/actions/_action_info.py
@@ -89,11 +89,6 @@ class ActionInfo(BaseModel):
     def model_post_init(self, __context: Any) -> None:
         ActionInfo._registry[self.key] = self
 
-    def mark_on_created(self, f: CoreActionFunc) -> CoreActionFunc:
-        """Decorator to mark a function to call when the QAction is created."""
-        self.on_created = f
-        return f
-
     def to_qaction(
         self, mmc: CMMCorePlus, parent: QObject | None = None
     ) -> QCoreAction:

--- a/src/pymmcore_gui/actions/_action_info.py
+++ b/src/pymmcore_gui/actions/_action_info.py
@@ -99,15 +99,17 @@ class ActionInfo(BaseModel):
     def for_key(cls, key: str) -> Self:
         """Get the ActionInfo for a given key."""
         if key not in ActionInfo._registry:
-            key_type = type(key).__name__
-            parent_module = __name__.rsplit(".", 1)[0]
-            if key_type == "WidgetAction":
-                module = f"{parent_module}.widget_actions"
-            else:
-                module = f"{parent_module}.core_actions"
+            # Find possible matches among available widget actions
+            import difflib
+
+            suggestion = ""
+            if matches := difflib.get_close_matches(
+                key, list(ActionInfo._registry), n=1, cutoff=0.5
+            ):
+                suggestion = f"\nDid you mean: {matches[0]}?"
+
             raise KeyError(
-                f"No 'ActionInfo' has been declared for key '{key_type}.{key}'. "
-                f"Please create one in {module}"
+                f"No 'ActionInfo' has been declared for key '{key}'.{suggestion}"
             )
 
         info = ActionInfo._registry[key]

--- a/src/pymmcore_gui/actions/_action_info.py
+++ b/src/pymmcore_gui/actions/_action_info.py
@@ -34,7 +34,7 @@ class ActionKey(str, Enum):
 
     def __str__(self) -> str:
         """Return value as the string representation."""
-        return str(self.value)
+        return str(self.name)
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}.{self.name}"
@@ -98,7 +98,7 @@ class ActionInfo:
             else:
                 module = f"{parent_module}.core_actions"
             raise KeyError(
-                f"No 'ActionInfo' has been declared for key '{key_type}.{key}'."
+                f"No 'ActionInfo' has been declared for key '{key_type}.{key}'. "
                 f"Please create one in {module}"
             )
 

--- a/src/pymmcore_gui/actions/_action_info.py
+++ b/src/pymmcore_gui/actions/_action_info.py
@@ -42,7 +42,7 @@ def ensure_isinstance(cls: type) -> PlainValidator:
     """Check if the value is an instance of the class."""
 
     def _check_type(value: Any) -> None:
-        if not isinstance(value, cls):
+        if not isinstance(value, cls):  # pragma: no cover
             raise TypeError(
                 f"Expected {cls.__name__}, got {type(value).__name__} instead."
             )

--- a/src/pymmcore_gui/actions/_action_info.py
+++ b/src/pymmcore_gui/actions/_action_info.py
@@ -106,7 +106,7 @@ class ActionInfo(BaseModel):
             if matches := difflib.get_close_matches(
                 key, list(ActionInfo._registry), n=1, cutoff=0.5
             ):
-                suggestion = f"\nDid you mean {matches[0]!r}?"
+                suggestion = f"\n\nDid you mean {matches[0]!r}?"
 
             raise KeyError(
                 f"No 'ActionInfo' has been declared for key '{key}'.{suggestion}"

--- a/src/pymmcore_gui/actions/_core_qaction.py
+++ b/src/pymmcore_gui/actions/_core_qaction.py
@@ -9,13 +9,13 @@ if TYPE_CHECKING:
     from pymmcore_plus import CMMCorePlus
     from PyQt6.QtCore import QObject
 
-    from ._action_info import ActionInfo, ActionKey, ActionTriggeredFunc
+    from ._action_info import ActionInfo, ActionTriggeredFunc
 
 
 class QCoreAction(QAction):
     """QAction that can act on a CMMCorePlus instance."""
 
-    key: ActionKey
+    key: str
 
     def __init__(
         self,

--- a/src/pymmcore_gui/actions/_core_qaction.py
+++ b/src/pymmcore_gui/actions/_core_qaction.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from PyQt6.QtGui import QAction, QIcon
 from superqt import QIconifyIcon
+from zmq import Enum
 
 if TYPE_CHECKING:
     from pymmcore_plus import CMMCorePlus
@@ -37,7 +38,10 @@ class QCoreAction(QAction):
         """Apply settings from a `CoreActionInfo` object to the QAction."""
         self.key = info.key
 
-        self.setText(info.text or str(info.key))
+        if not (text := info.text):
+            text = info.key.value if isinstance(info.key, Enum) else info.key
+
+        self.setText(text)
         if info.auto_repeat is not None:
             self.setAutoRepeat(info.auto_repeat)
         if info.checkable is not None:

--- a/src/pymmcore_gui/actions/_core_qaction.py
+++ b/src/pymmcore_gui/actions/_core_qaction.py
@@ -54,6 +54,7 @@ class QCoreAction(QAction):
             if isinstance(info.icon, str):
                 icon: QIcon = QIconifyIcon(info.icon)
             else:
+                breakpoint()
                 icon = QIcon(info.icon)
             self.setIcon(icon)
         if info.icon_text is not None:

--- a/src/pymmcore_gui/actions/_core_qaction.py
+++ b/src/pymmcore_gui/actions/_core_qaction.py
@@ -54,7 +54,6 @@ class QCoreAction(QAction):
             if isinstance(info.icon, str):
                 icon: QIcon = QIconifyIcon(info.icon)
             else:
-                breakpoint()
                 icon = QIcon(info.icon)
             self.setIcon(icon)
         if info.icon_text is not None:

--- a/src/pymmcore_gui/actions/core_actions.py
+++ b/src/pymmcore_gui/actions/core_actions.py
@@ -1,4 +1,4 @@
-"""Define actions that act on the global CMMCore instance."""
+"""Defines actions that act on the global CMMCore instance."""
 
 from __future__ import annotations
 

--- a/src/pymmcore_gui/actions/core_actions.py
+++ b/src/pymmcore_gui/actions/core_actions.py
@@ -10,15 +10,13 @@ if TYPE_CHECKING:
     from ._core_qaction import QCoreAction
 
 
+# ######################## Functions acting on the Core #########################
 class CoreAction(ActionKey):
     """Actions that act on the global CMMCore instance."""
 
-    SNAP = "Snap Image"
-    TOGGLE_LIVE = "Toggle Live"
-    LOAD_DEMO = "Load Demo Configuration"
-
-
-# ######################## Functions acting on the Core #########################
+    SNAP = "pymmcore_gui.snap_image"
+    TOGGLE_LIVE = "pymmcore_gui.toggle_live"
+    LOAD_DEMO = "pymmcore_gui.load_demo_config"
 
 
 # TODO: perhaps have alternate signatures for these functions that take a
@@ -58,8 +56,10 @@ def load_demo_config(action: QCoreAction, checked: bool) -> None:
 
 # ########################## Action Info Instances #############################
 
+
 snap_action = ActionInfo(
     key=CoreAction.SNAP,
+    text="Snap Image",
     shortcut="Ctrl+K",
     auto_repeat=True,
     icon="mdi-light:camera",
@@ -69,6 +69,7 @@ snap_action = ActionInfo(
 
 toggle_live_action = ActionInfo(
     key=CoreAction.TOGGLE_LIVE,
+    text="Toggle Live",
     shortcut="Ctrl+L",
     auto_repeat=True,
     icon="mdi:video-outline",
@@ -79,5 +80,6 @@ toggle_live_action = ActionInfo(
 
 load_demo_action = ActionInfo(
     key=CoreAction.LOAD_DEMO,
+    text="Load Demo Configuration",
     on_triggered=load_demo_config,
 )

--- a/src/pymmcore_gui/actions/widget_actions.py
+++ b/src/pymmcore_gui/actions/widget_actions.py
@@ -193,6 +193,7 @@ class WidgetActionInfo(ActionInfo, Generic[WT]):
             raise ValueError(
                 f"WidgetActionInfo for {self.key!r} must have a create_widget function."
             )
+        super().__post_init__()
 
 
 show_about = WidgetActionInfo(

--- a/src/pymmcore_gui/actions/widget_actions.py
+++ b/src/pymmcore_gui/actions/widget_actions.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable  # noqa: TC003
-from typing import TYPE_CHECKING, Annotated, cast
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Annotated, TypeVar, cast
 
 from pymmcore_plus import CMMCorePlus
 from PyQt6.QtCore import Qt
@@ -11,9 +11,7 @@ from PyQt6.QtGui import QAction
 from PyQt6.QtWidgets import QDialog, QWidget
 from PyQt6Ads import CDockWidget, DockWidgetArea, SideBarLocation
 
-from pymmcore_gui.actions._action_info import ActionKey
-
-from ._action_info import ActionInfo, ensure_isinstance
+from ._action_info import ActionKey, WidgetActionInfo, _ensure_isinstance
 
 if TYPE_CHECKING:
     import pymmcore_widgets as pmmw
@@ -23,6 +21,26 @@ if TYPE_CHECKING:
     from pymmcore_gui.widgets._exception_log import ExceptionLog
     from pymmcore_gui.widgets._mm_console import MMConsole
     from pymmcore_gui.widgets._stage_control import StagesControlWidget
+
+QWidgetType = Annotated[QWidget, _ensure_isinstance(QWidget)]
+
+CT = TypeVar("CT", bound=Callable[[QWidget], QWidget])
+
+
+class WidgetAction(ActionKey):
+    """Widget Actions toggle/create singleton widgets."""
+
+    ABOUT = "pymmcore_gui.about_widget"
+    PROP_BROWSER = "pymmcore_gui.property_browser"
+    PIXEL_CONFIG = "pymmcore_gui.pixel_config_widget"
+    INSTALL_DEVICES = "pymmcore_gui.install_devices_widget"
+    MDA_WIDGET = "pymmcore_gui.mda_widget"
+    CONFIG_GROUPS = "pymmcore_gui.config_groups_widget"
+    CAMERA_ROI = "pymmcore_gui.camera_roi_widget"
+    CONSOLE = "pymmcore_gui.console"
+    EXCEPTION_LOG = "pymmcore_gui.exception_log"
+    STAGE_CONTROL = "pymmcore_gui.stage_control_widget"
+    CONFIG_WIZARD = "pymmcore_gui.hardware_config_wizard"
 
 
 # ######################## Functions that create widgets #########################
@@ -50,13 +68,6 @@ def create_property_browser(parent: QWidget) -> pmmw.PropertyBrowser:
     from pymmcore_widgets import PropertyBrowser
 
     return PropertyBrowser(parent=parent, mmcore=_get_core(parent))
-
-
-def create_about_widget(parent: QWidget) -> QWidget:
-    """Create an "about this program" widget."""
-    from pymmcore_gui.widgets._about_widget import AboutWidget
-
-    return AboutWidget(parent=parent)
 
 
 def create_mm_console(parent: QWidget) -> MMConsole:
@@ -136,57 +147,19 @@ def create_config_wizard(parent: QWidget) -> pmmw.ConfigWizard:
 # ######################## WidgetAction Enum #########################
 
 
-class WidgetAction(ActionKey):
-    """Widget Actions toggle/create singleton widgets."""
-
-    ABOUT = "About Pymmcore Gui"
-    PROP_BROWSER = "Property Browser"
-    PIXEL_CONFIG = "Pixel Configuration"
-    INSTALL_DEVICES = "Install Devices"
-    MDA_WIDGET = "MDA Widget"
-    CONFIG_GROUPS = "Configs and Preset"
-    CAMERA_ROI = "Camera ROI"
-    CONSOLE = "Console"
-    EXCEPTION_LOG = "Exception Log"
-    STAGE_CONTROL = "Stage Control"
-    CONFIG_WIZARD = "Hardware Config Wizard"
-
-    def create_widget(self, parent: QWidget) -> QWidget:
-        """Create the widget associated with this action."""
-        info: WidgetActionInfo = WidgetActionInfo.for_key(self)
-        return info.create_widget(parent)
-
-    def dock_area(self) -> DockWidgetArea | SideBarLocation | None:
-        """Return the default dock area for this widget."""
-        return WidgetActionInfo.for_key(self).dock_area
-
-    def scroll_mode(self) -> CDockWidget.eInsertMode:
-        """Return the default scroll mode for this widget."""
-        return WidgetActionInfo.for_key(self).scroll_mode
-
-
 # ######################## WidgetActionInfos #########################
 
 
-QWidgetType = Annotated[QWidget, ensure_isinstance(QWidget)]
+def create_about_widget(parent: QWidget) -> QWidget:
+    """Create an "about this program" widget."""
+    from pymmcore_gui.widgets._about_widget import AboutWidget
 
-
-class WidgetActionInfo(ActionInfo):
-    """Subclass to set default values for WidgetAction."""
-
-    # by default, widget actions are checkable, and the check state indicates visibility
-    checkable: bool = True
-    # function that can be called with (parent: QWidget) -> QWidget
-    create_widget: Callable[[QWidgetType], QWidget]
-    # Use None to indicate that the widget should not be docked
-    dock_area: DockWidgetArea | SideBarLocation | None = (
-        DockWidgetArea.RightDockWidgetArea
-    )
-    scroll_mode: CDockWidget.eInsertMode = CDockWidget.eInsertMode.AutoScrollArea
+    return AboutWidget(parent=parent)
 
 
 show_about = WidgetActionInfo(
     key=WidgetAction.ABOUT,
+    text="About Pymmcore Gui",
     create_widget=create_about_widget,
     dock_area=None,
     checkable=False,
@@ -196,6 +169,7 @@ show_about = WidgetActionInfo(
 
 show_console = WidgetActionInfo(
     key=WidgetAction.CONSOLE,
+    text="Console",
     shortcut="Ctrl+Shift+C",
     icon="iconoir:terminal",
     create_widget=create_mm_console,
@@ -204,6 +178,7 @@ show_console = WidgetActionInfo(
 
 show_property_browser = WidgetActionInfo(
     key=WidgetAction.PROP_BROWSER,
+    text="Property Browser",
     shortcut="Ctrl+Shift+P",
     icon="mdi-light:format-list-bulleted",
     create_widget=create_property_browser,
@@ -212,6 +187,7 @@ show_property_browser = WidgetActionInfo(
 
 show_install_devices = WidgetActionInfo(
     key=WidgetAction.INSTALL_DEVICES,
+    text="Install Devices",
     shortcut="Ctrl+Shift+I",
     icon="mdi-light:download",
     create_widget=create_install_widgets,
@@ -222,6 +198,7 @@ show_install_devices = WidgetActionInfo(
 
 show_mda_widget = WidgetActionInfo(
     key=WidgetAction.MDA_WIDGET,
+    text="MDA",
     shortcut="Ctrl+Shift+M",
     icon="qlementine-icons:cube-16",
     create_widget=create_mda_widget,
@@ -229,6 +206,7 @@ show_mda_widget = WidgetActionInfo(
 
 show_camera_roi = WidgetActionInfo(
     key=WidgetAction.CAMERA_ROI,
+    text="Camera ROI",
     shortcut="Ctrl+Shift+R",
     icon="material-symbols-light:screenshot-region-rounded",
     create_widget=create_camera_roi,
@@ -237,6 +215,7 @@ show_camera_roi = WidgetActionInfo(
 
 show_config_groups = WidgetActionInfo(
     key=WidgetAction.CONFIG_GROUPS,
+    text="Config Groups",
     shortcut="Ctrl+Shift+G",
     icon="mdi-light:format-list-bulleted",
     create_widget=create_config_groups,
@@ -246,6 +225,7 @@ show_config_groups = WidgetActionInfo(
 
 show_pixel_config = WidgetActionInfo(
     key=WidgetAction.PIXEL_CONFIG,
+    text="Pixel Size Configuration",
     shortcut="Ctrl+Shift+X",
     icon="mdi-light:grid",
     create_widget=create_pixel_config,
@@ -253,6 +233,7 @@ show_pixel_config = WidgetActionInfo(
 
 show_exception_log = WidgetActionInfo(
     key=WidgetAction.EXCEPTION_LOG,
+    text="Exception Log",
     shortcut="Ctrl+Shift+E",
     icon="mdi-light:alert",
     create_widget=create_exception_log,
@@ -261,6 +242,7 @@ show_exception_log = WidgetActionInfo(
 
 show_stage_control = WidgetActionInfo(
     key=WidgetAction.STAGE_CONTROL,
+    text="Stage Control",
     shortcut="Ctrl+Shift+S",
     icon="fa:arrows",
     create_widget=create_stage_widget,
@@ -269,6 +251,7 @@ show_stage_control = WidgetActionInfo(
 
 show_config_wizard = WidgetActionInfo(
     key=WidgetAction.CONFIG_WIZARD,
+    text="Hardware Config Wizard",
     icon="mdi:cog",
     create_widget=create_config_wizard,
     dock_area=None,

--- a/src/pymmcore_gui/widgets/_notifications.py
+++ b/src/pymmcore_gui/widgets/_notifications.py
@@ -78,7 +78,7 @@ class NotificationToast(QWidget):
             ic = QIconifyIcon("codicon:info", color="#0af")
         self.icon.setPixmap(ic.pixmap(20, 20))
 
-        self.message_label = QLabel(notification.message)
+        self.message_label = QLabel(notification.message.replace(r"\n", "<br>"))
         self.message_label.setWordWrap(True)
         self.message_label.setTextInteractionFlags(
             Qt.TextInteractionFlag.TextSelectableByMouse

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,0 +1,19 @@
+import pytest
+
+from pymmcore_gui.actions import ActionInfo, CoreAction
+from pymmcore_gui.actions._action_info import WidgetActionInfo
+from pymmcore_gui.actions.widget_actions import WidgetAction
+
+
+def test_action_registry():
+    info = ActionInfo.for_key(CoreAction.SNAP)
+    assert info.text == "Snap Image"
+
+    with pytest.raises(KeyError, match=f"Did you mean {CoreAction.LOAD_DEMO.value!r}?"):
+        ActionInfo.for_key(CoreAction.LOAD_DEMO.value[:-2])
+
+    with pytest.raises(TypeError, match="is not an instance of"):
+        info = WidgetActionInfo.for_key(CoreAction.SNAP)
+
+    info = WidgetActionInfo.for_key(WidgetAction.ABOUT)
+    assert info in ActionInfo.widget_actions().values()

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,8 +1,8 @@
 import pytest
+from PyQt6.QtWidgets import QMenu, QWidget
 
-from pymmcore_gui.actions import ActionInfo, CoreAction
-from pymmcore_gui.actions._action_info import WidgetActionInfo
-from pymmcore_gui.actions.widget_actions import WidgetAction
+from pymmcore_gui import MicroManagerGUI
+from pymmcore_gui.actions import ActionInfo, CoreAction, WidgetAction, WidgetActionInfo
 
 
 def test_action_registry():
@@ -14,6 +14,27 @@ def test_action_registry():
 
     with pytest.raises(TypeError, match="is not an instance of"):
         info = WidgetActionInfo.for_key(CoreAction.SNAP)
-
     info = WidgetActionInfo.for_key(WidgetAction.ABOUT)
-    assert info in ActionInfo.widget_actions().values()
+
+
+@pytest.mark.usefixtures("qapp")
+def test_actions_in_menus():
+    # people can add new ones
+    text = "My Widget!!!!"
+    act = WidgetActionInfo(
+        key="mywidget",
+        text=text,
+        icon="mdi-light:format-list-bulleted",
+        create_widget=lambda p: QWidget(p),
+    )
+    assert "mywidget" in WidgetActionInfo._registry
+    assert act in ActionInfo.widget_actions().values()
+
+    win = MicroManagerGUI()
+    mb = win.menuBar()
+    assert mb
+    window_menu = next(
+        (m for a in mb.actions() if (m := a.menu()) and m.title() == "Window"), None
+    )
+    assert isinstance(window_menu, QMenu)
+    assert any(a.text() == text for a in window_menu.actions())

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -8,6 +8,7 @@ from pytest import MonkeyPatch
 from pymmcore_gui import __main__, _app
 
 
+@pytest.mark.order(0)
 def test_main_app(monkeypatch: MonkeyPatch) -> None:
     with patch.object(
         _app.MMQApplication, "exec", lambda _: QApplication.processEvents()

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -9,9 +9,10 @@ from pymmcore_widgets import MDAWidget
 from PyQt6.QtWidgets import QApplication, QDialog
 from PyQt6Ads import CDockWidget
 
-from pymmcore_gui import CoreAction, MicroManagerGUI, WidgetAction
+from pymmcore_gui import MicroManagerGUI
 from pymmcore_gui._app import MMQApplication
 from pymmcore_gui._notification_manager import NotificationManager
+from pymmcore_gui.actions import CoreAction, WidgetAction
 from pymmcore_gui.widgets._toolbars import ShuttersToolbar
 
 if TYPE_CHECKING:

--- a/uv.lock
+++ b/uv.lock
@@ -52,11 +52,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2025.1.31"
+version = "2025.4.26"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1c/ab/c9f1e32b7b1bf505bf26f0ef697775960db7932abeb7b516de930ba2705f/certifi-2025.1.31.tar.gz", hash = "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651", size = 167577 }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/9e/c05b3920a3b7d20d3d3310465f50348e5b3694f4f88c6daf736eef3024c4/certifi-2025.4.26.tar.gz", hash = "sha256:0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6", size = 160705 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/fc/bce832fd4fd99766c04d1ee0eead6b0ec6486fb100ae5e74c1d91292b982/certifi-2025.1.31-py3-none-any.whl", hash = "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe", size = 166393 },
+    { url = "https://files.pythonhosted.org/packages/4a/7e/3db2bd1b1f9e95f7cddca6d6e75e2f2bd9f51b1246e546d88addca0106bd/certifi-2025.4.26-py3-none-any.whl", hash = "sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3", size = 159618 },
 ]
 
 [[package]]
@@ -123,6 +123,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/11/74/539e56497d9bd1d484fd863dd69cbbfa653cd2aa27abfe35653494d85e94/cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560", size = 7114 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/55/51844dd50c4fc7a33b653bfaba4c2456f06955289ca770a5dbd5fd267374/cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9", size = 7249 },
+]
+
+[[package]]
+name = "chardet"
+version = "5.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/f7b6ab21ec75897ed80c17d79b15951a719226b9fababf1e40ea74d69079/chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7", size = 2069618 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/6f/f5fbc992a329ee4e0f288c1fe0e2ad9485ed064cac731ed2fe47dcc38cbf/chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970", size = 199385 },
 ]
 
 [[package]]
@@ -343,6 +352,21 @@ wheels = [
 ]
 
 [[package]]
+name = "diff-cover"
+version = "9.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "chardet" },
+    { name = "jinja2" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/a8/20e11859ee291893ef9711ca868d277b66cdf886278e73abdb72b172cc5f/diff_cover-9.2.4.tar.gz", hash = "sha256:6ea44711f09199a1b8bcaa2eae002e1f337dd22f2d798fcfd62a6a1554bb2a86", size = 91359 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/86/45de73eea30a789350ec91a83cdd525a68ac1ed294ae1a24e7de984e971d/diff_cover-9.2.4-py3-none-any.whl", hash = "sha256:c68b34e368b13888cb04a14aeb509821aab594c171a621e8bd3248435c9dd0c9", size = 53185 },
+]
+
+[[package]]
 name = "distlib"
 version = "0.3.9"
 source = { registry = "https://pypi.org/simple" }
@@ -478,8 +502,8 @@ dependencies = [
     { name = "appnope", marker = "sys_platform == 'darwin'" },
     { name = "comm" },
     { name = "debugpy" },
-    { name = "ipython", version = "8.35.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "ipython", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "ipython", version = "8.36.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "ipython", version = "9.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "jupyter-client" },
     { name = "jupyter-core" },
     { name = "matplotlib-inline" },
@@ -497,7 +521,7 @@ wheels = [
 
 [[package]]
 name = "ipython"
-version = "8.35.0"
+version = "8.36.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.11'",
@@ -515,14 +539,14 @@ dependencies = [
     { name = "traitlets", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/77/7d1501e8b539b179936e0d5969b578ed23887be0ab8c63e0120b825bda3e/ipython-8.35.0.tar.gz", hash = "sha256:d200b7d93c3f5883fc36ab9ce28a18249c7706e51347681f80a0aef9895f2520", size = 5605027 }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/9f/d9a73710df947b7804bd9d93509463fb3a89e0ddc99c9fcc67279cddbeb6/ipython-8.36.0.tar.gz", hash = "sha256:24658e9fe5c5c819455043235ba59cfffded4a35936eefceceab6b192f7092ff", size = 5604997 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/bf/17ffca8c8b011d0bac90adb5d4e720cb3ae1fe5ccfdfc14ca31f827ee320/ipython-8.35.0-py3-none-any.whl", hash = "sha256:e6b7470468ba6f1f0a7b116bb688a3ece2f13e2f94138e508201fad677a788ba", size = 830880 },
+    { url = "https://files.pythonhosted.org/packages/d6/d7/c1c9f371790b3a181e343c4815a361e5a0cc7d90ef6642d64ba5d05de289/ipython-8.36.0-py3-none-any.whl", hash = "sha256:12b913914d010dcffa2711505ec8be4bf0180742d97f1e5175e51f22086428c1", size = 831074 },
 ]
 
 [[package]]
 name = "ipython"
-version = "9.1.0"
+version = "9.2.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -542,9 +566,9 @@ dependencies = [
     { name = "traitlets", marker = "python_full_version >= '3.11'" },
     { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/70/9a/6b8984bedc990f3a4aa40ba8436dea27e23d26a64527de7c2e5e12e76841/ipython-9.1.0.tar.gz", hash = "sha256:a47e13a5e05e02f3b8e1e7a0f9db372199fe8c3763532fe7a1e0379e4e135f16", size = 4373688 }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/02/63a84444a7409b3c0acd1de9ffe524660e0e5d82ee473e78b45e5bfb64a4/ipython-9.2.0.tar.gz", hash = "sha256:62a9373dbc12f28f9feaf4700d052195bf89806279fc8ca11f3f54017d04751b", size = 4424394 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/9d/4ff2adf55d1b6e3777b0303fdbe5b723f76e46cba4a53a32fe82260d2077/ipython-9.1.0-py3-none-any.whl", hash = "sha256:2df07257ec2f84a6b346b8d83100bcf8fa501c6e01ab75cd3799b0bb253b3d2a", size = 604053 },
+    { url = "https://files.pythonhosted.org/packages/78/ce/5e897ee51b7d26ab4e47e5105e7368d40ce6cfae2367acdf3165396d50be/ipython-9.2.0-py3-none-any.whl", hash = "sha256:fef5e33c4a1ae0759e0bba5917c9db4eb8c53fee917b6a526bd973e1ca5159f6", size = 604277 },
 ]
 
 [[package]]
@@ -569,6 +593,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/72/3a/79a912fbd4d8dd6fbb02bf69afd3bb72cf0c729bb3063c6f4498603db17a/jedi-0.19.2.tar.gz", hash = "sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0", size = 1231287 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl", hash = "sha256:a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9", size = 1572278 },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899 },
 ]
 
 [[package]]
@@ -710,6 +746,64 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528 },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0", size = 20537 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/90/d08277ce111dd22f77149fd1a5d4653eeb3b3eaacbdfcbae5afb2600eebd/MarkupSafe-3.0.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7e94c425039cde14257288fd61dcfb01963e658efbc0ff54f5306b06054700f8", size = 14357 },
+    { url = "https://files.pythonhosted.org/packages/04/e1/6e2194baeae0bca1fae6629dc0cbbb968d4d941469cbab11a3872edff374/MarkupSafe-3.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9e2d922824181480953426608b81967de705c3cef4d1af983af849d7bd619158", size = 12393 },
+    { url = "https://files.pythonhosted.org/packages/1d/69/35fa85a8ece0a437493dc61ce0bb6d459dcba482c34197e3efc829aa357f/MarkupSafe-3.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:38a9ef736c01fccdd6600705b09dc574584b89bea478200c5fbf112a6b0d5579", size = 21732 },
+    { url = "https://files.pythonhosted.org/packages/22/35/137da042dfb4720b638d2937c38a9c2df83fe32d20e8c8f3185dbfef05f7/MarkupSafe-3.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bbcb445fa71794da8f178f0f6d66789a28d7319071af7a496d4d507ed566270d", size = 20866 },
+    { url = "https://files.pythonhosted.org/packages/29/28/6d029a903727a1b62edb51863232152fd335d602def598dade38996887f0/MarkupSafe-3.0.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:57cb5a3cf367aeb1d316576250f65edec5bb3be939e9247ae594b4bcbc317dfb", size = 20964 },
+    { url = "https://files.pythonhosted.org/packages/cc/cd/07438f95f83e8bc028279909d9c9bd39e24149b0d60053a97b2bc4f8aa51/MarkupSafe-3.0.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:3809ede931876f5b2ec92eef964286840ed3540dadf803dd570c3b7e13141a3b", size = 21977 },
+    { url = "https://files.pythonhosted.org/packages/29/01/84b57395b4cc062f9c4c55ce0df7d3108ca32397299d9df00fedd9117d3d/MarkupSafe-3.0.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e07c3764494e3776c602c1e78e298937c3315ccc9043ead7e685b7f2b8d47b3c", size = 21366 },
+    { url = "https://files.pythonhosted.org/packages/bd/6e/61ebf08d8940553afff20d1fb1ba7294b6f8d279df9fd0c0db911b4bbcfd/MarkupSafe-3.0.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b424c77b206d63d500bcb69fa55ed8d0e6a3774056bdc4839fc9298a7edca171", size = 21091 },
+    { url = "https://files.pythonhosted.org/packages/11/23/ffbf53694e8c94ebd1e7e491de185124277964344733c45481f32ede2499/MarkupSafe-3.0.2-cp310-cp310-win32.whl", hash = "sha256:fcabf5ff6eea076f859677f5f0b6b5c1a51e70a376b0579e0eadef8db48c6b50", size = 15065 },
+    { url = "https://files.pythonhosted.org/packages/44/06/e7175d06dd6e9172d4a69a72592cb3f7a996a9c396eee29082826449bbc3/MarkupSafe-3.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:6af100e168aa82a50e186c82875a5893c5597a0c1ccdb0d8b40240b1f28b969a", size = 15514 },
+    { url = "https://files.pythonhosted.org/packages/6b/28/bbf83e3f76936960b850435576dd5e67034e200469571be53f69174a2dfd/MarkupSafe-3.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9025b4018f3a1314059769c7bf15441064b2207cb3f065e6ea1e7359cb46db9d", size = 14353 },
+    { url = "https://files.pythonhosted.org/packages/6c/30/316d194b093cde57d448a4c3209f22e3046c5bb2fb0820b118292b334be7/MarkupSafe-3.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:93335ca3812df2f366e80509ae119189886b0f3c2b81325d39efdb84a1e2ae93", size = 12392 },
+    { url = "https://files.pythonhosted.org/packages/f2/96/9cdafba8445d3a53cae530aaf83c38ec64c4d5427d975c974084af5bc5d2/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2cb8438c3cbb25e220c2ab33bb226559e7afb3baec11c4f218ffa7308603c832", size = 23984 },
+    { url = "https://files.pythonhosted.org/packages/f1/a4/aefb044a2cd8d7334c8a47d3fb2c9f328ac48cb349468cc31c20b539305f/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a123e330ef0853c6e822384873bef7507557d8e4a082961e1defa947aa59ba84", size = 23120 },
+    { url = "https://files.pythonhosted.org/packages/8d/21/5e4851379f88f3fad1de30361db501300d4f07bcad047d3cb0449fc51f8c/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e084f686b92e5b83186b07e8a17fc09e38fff551f3602b249881fec658d3eca", size = 23032 },
+    { url = "https://files.pythonhosted.org/packages/00/7b/e92c64e079b2d0d7ddf69899c98842f3f9a60a1ae72657c89ce2655c999d/MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d8213e09c917a951de9d09ecee036d5c7d36cb6cb7dbaece4c71a60d79fb9798", size = 24057 },
+    { url = "https://files.pythonhosted.org/packages/f9/ac/46f960ca323037caa0a10662ef97d0a4728e890334fc156b9f9e52bcc4ca/MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:5b02fb34468b6aaa40dfc198d813a641e3a63b98c2b05a16b9f80b7ec314185e", size = 23359 },
+    { url = "https://files.pythonhosted.org/packages/69/84/83439e16197337b8b14b6a5b9c2105fff81d42c2a7c5b58ac7b62ee2c3b1/MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0bff5e0ae4ef2e1ae4fdf2dfd5b76c75e5c2fa4132d05fc1b0dabcd20c7e28c4", size = 23306 },
+    { url = "https://files.pythonhosted.org/packages/9a/34/a15aa69f01e2181ed8d2b685c0d2f6655d5cca2c4db0ddea775e631918cd/MarkupSafe-3.0.2-cp311-cp311-win32.whl", hash = "sha256:6c89876f41da747c8d3677a2b540fb32ef5715f97b66eeb0c6b66f5e3ef6f59d", size = 15094 },
+    { url = "https://files.pythonhosted.org/packages/da/b8/3a3bd761922d416f3dc5d00bfbed11f66b1ab89a0c2b6e887240a30b0f6b/MarkupSafe-3.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:70a87b411535ccad5ef2f1df5136506a10775d267e197e4cf531ced10537bd6b", size = 15521 },
+    { url = "https://files.pythonhosted.org/packages/22/09/d1f21434c97fc42f09d290cbb6350d44eb12f09cc62c9476effdb33a18aa/MarkupSafe-3.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9778bd8ab0a994ebf6f84c2b949e65736d5575320a17ae8984a77fab08db94cf", size = 14274 },
+    { url = "https://files.pythonhosted.org/packages/6b/b0/18f76bba336fa5aecf79d45dcd6c806c280ec44538b3c13671d49099fdd0/MarkupSafe-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:846ade7b71e3536c4e56b386c2a47adf5741d2d8b94ec9dc3e92e5e1ee1e2225", size = 12348 },
+    { url = "https://files.pythonhosted.org/packages/e0/25/dd5c0f6ac1311e9b40f4af06c78efde0f3b5cbf02502f8ef9501294c425b/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c99d261bd2d5f6b59325c92c73df481e05e57f19837bdca8413b9eac4bd8028", size = 24149 },
+    { url = "https://files.pythonhosted.org/packages/f3/f0/89e7aadfb3749d0f52234a0c8c7867877876e0a20b60e2188e9850794c17/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e17c96c14e19278594aa4841ec148115f9c7615a47382ecb6b82bd8fea3ab0c8", size = 23118 },
+    { url = "https://files.pythonhosted.org/packages/d5/da/f2eeb64c723f5e3777bc081da884b414671982008c47dcc1873d81f625b6/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:88416bd1e65dcea10bc7569faacb2c20ce071dd1f87539ca2ab364bf6231393c", size = 22993 },
+    { url = "https://files.pythonhosted.org/packages/da/0e/1f32af846df486dce7c227fe0f2398dc7e2e51d4a370508281f3c1c5cddc/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2181e67807fc2fa785d0592dc2d6206c019b9502410671cc905d132a92866557", size = 24178 },
+    { url = "https://files.pythonhosted.org/packages/c4/f6/bb3ca0532de8086cbff5f06d137064c8410d10779c4c127e0e47d17c0b71/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:52305740fe773d09cffb16f8ed0427942901f00adedac82ec8b67752f58a1b22", size = 23319 },
+    { url = "https://files.pythonhosted.org/packages/a2/82/8be4c96ffee03c5b4a034e60a31294daf481e12c7c43ab8e34a1453ee48b/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ad10d3ded218f1039f11a75f8091880239651b52e9bb592ca27de44eed242a48", size = 23352 },
+    { url = "https://files.pythonhosted.org/packages/51/ae/97827349d3fcffee7e184bdf7f41cd6b88d9919c80f0263ba7acd1bbcb18/MarkupSafe-3.0.2-cp312-cp312-win32.whl", hash = "sha256:0f4ca02bea9a23221c0182836703cbf8930c5e9454bacce27e767509fa286a30", size = 15097 },
+    { url = "https://files.pythonhosted.org/packages/c1/80/a61f99dc3a936413c3ee4e1eecac96c0da5ed07ad56fd975f1a9da5bc630/MarkupSafe-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:8e06879fc22a25ca47312fbe7c8264eb0b662f6db27cb2d3bbbc74b1df4b9b87", size = 15601 },
+    { url = "https://files.pythonhosted.org/packages/83/0e/67eb10a7ecc77a0c2bbe2b0235765b98d164d81600746914bebada795e97/MarkupSafe-3.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ba9527cdd4c926ed0760bc301f6728ef34d841f405abf9d4f959c478421e4efd", size = 14274 },
+    { url = "https://files.pythonhosted.org/packages/2b/6d/9409f3684d3335375d04e5f05744dfe7e9f120062c9857df4ab490a1031a/MarkupSafe-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f8b3d067f2e40fe93e1ccdd6b2e1d16c43140e76f02fb1319a05cf2b79d99430", size = 12352 },
+    { url = "https://files.pythonhosted.org/packages/d2/f5/6eadfcd3885ea85fe2a7c128315cc1bb7241e1987443d78c8fe712d03091/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:569511d3b58c8791ab4c2e1285575265991e6d8f8700c7be0e88f86cb0672094", size = 24122 },
+    { url = "https://files.pythonhosted.org/packages/0c/91/96cf928db8236f1bfab6ce15ad070dfdd02ed88261c2afafd4b43575e9e9/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15ab75ef81add55874e7ab7055e9c397312385bd9ced94920f2802310c930396", size = 23085 },
+    { url = "https://files.pythonhosted.org/packages/c2/cf/c9d56af24d56ea04daae7ac0940232d31d5a8354f2b457c6d856b2057d69/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f3818cb119498c0678015754eba762e0d61e5b52d34c8b13d770f0719f7b1d79", size = 22978 },
+    { url = "https://files.pythonhosted.org/packages/2a/9f/8619835cd6a711d6272d62abb78c033bda638fdc54c4e7f4272cf1c0962b/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cdb82a876c47801bb54a690c5ae105a46b392ac6099881cdfb9f6e95e4014c6a", size = 24208 },
+    { url = "https://files.pythonhosted.org/packages/f9/bf/176950a1792b2cd2102b8ffeb5133e1ed984547b75db47c25a67d3359f77/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:cabc348d87e913db6ab4aa100f01b08f481097838bdddf7c7a84b7575b7309ca", size = 23357 },
+    { url = "https://files.pythonhosted.org/packages/ce/4f/9a02c1d335caabe5c4efb90e1b6e8ee944aa245c1aaaab8e8a618987d816/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:444dcda765c8a838eaae23112db52f1efaf750daddb2d9ca300bcae1039adc5c", size = 23344 },
+    { url = "https://files.pythonhosted.org/packages/ee/55/c271b57db36f748f0e04a759ace9f8f759ccf22b4960c270c78a394f58be/MarkupSafe-3.0.2-cp313-cp313-win32.whl", hash = "sha256:bcf3e58998965654fdaff38e58584d8937aa3096ab5354d493c77d1fdd66d7a1", size = 15101 },
+    { url = "https://files.pythonhosted.org/packages/29/88/07df22d2dd4df40aba9f3e402e6dc1b8ee86297dddbad4872bd5e7b0094f/MarkupSafe-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:e6a2a455bd412959b57a172ce6328d2dd1f01cb2135efda2e4576e8a23fa3b0f", size = 15603 },
+    { url = "https://files.pythonhosted.org/packages/62/6a/8b89d24db2d32d433dffcd6a8779159da109842434f1dd2f6e71f32f738c/MarkupSafe-3.0.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b5a6b3ada725cea8a5e634536b1b01c30bcdcd7f9c6fff4151548d5bf6b3a36c", size = 14510 },
+    { url = "https://files.pythonhosted.org/packages/7a/06/a10f955f70a2e5a9bf78d11a161029d278eeacbd35ef806c3fd17b13060d/MarkupSafe-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a904af0a6162c73e3edcb969eeeb53a63ceeb5d8cf642fade7d39e7963a22ddb", size = 12486 },
+    { url = "https://files.pythonhosted.org/packages/34/cf/65d4a571869a1a9078198ca28f39fba5fbb910f952f9dbc5220afff9f5e6/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aa4e5faecf353ed117801a068ebab7b7e09ffb6e1d5e412dc852e0da018126c", size = 25480 },
+    { url = "https://files.pythonhosted.org/packages/0c/e3/90e9651924c430b885468b56b3d597cabf6d72be4b24a0acd1fa0e12af67/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0ef13eaeee5b615fb07c9a7dadb38eac06a0608b41570d8ade51c56539e509d", size = 23914 },
+    { url = "https://files.pythonhosted.org/packages/66/8c/6c7cf61f95d63bb866db39085150df1f2a5bd3335298f14a66b48e92659c/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d16a81a06776313e817c951135cf7340a3e91e8c1ff2fac444cfd75fffa04afe", size = 23796 },
+    { url = "https://files.pythonhosted.org/packages/bb/35/cbe9238ec3f47ac9a7c8b3df7a808e7cb50fe149dc7039f5f454b3fba218/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6381026f158fdb7c72a168278597a5e3a5222e83ea18f543112b2662a9b699c5", size = 25473 },
+    { url = "https://files.pythonhosted.org/packages/e6/32/7621a4382488aa283cc05e8984a9c219abad3bca087be9ec77e89939ded9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:3d79d162e7be8f996986c064d1c7c817f6df3a77fe3d6859f6f9e7be4b8c213a", size = 24114 },
+    { url = "https://files.pythonhosted.org/packages/0d/80/0985960e4b89922cb5a0bac0ed39c5b96cbc1a536a99f30e8c220a996ed9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9", size = 24098 },
+    { url = "https://files.pythonhosted.org/packages/82/78/fedb03c7d5380df2427038ec8d973587e90561b2d90cd472ce9254cf348b/MarkupSafe-3.0.2-cp313-cp313t-win32.whl", hash = "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6", size = 15208 },
+    { url = "https://files.pythonhosted.org/packages/4f/65/6079a46068dfceaeabb5dcad6d674f5f5c61a6fa5673746f42a9f4c233b3/MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f", size = 15739 },
 ]
 
 [[package]]
@@ -1484,8 +1578,9 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "ipython", version = "8.35.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "ipython", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "diff-cover" },
+    { name = "ipython", version = "8.36.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "ipython", version = "9.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pyautogui" },
@@ -1493,6 +1588,7 @@ dev = [
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-order" },
     { name = "pytest-qt" },
     { name = "rich" },
     { name = "ruff" },
@@ -1501,6 +1597,13 @@ dev = [
     { name = "types-pygments" },
     { name = "types-pyinstaller" },
     { name = "types-pyyaml" },
+]
+test = [
+    { name = "pyautogui" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-order" },
+    { name = "pytest-qt" },
 ]
 
 [package.metadata]
@@ -1524,6 +1627,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "diff-cover", specifier = ">=9.2.4" },
     { name = "ipython", specifier = ">=8.30.0" },
     { name = "mypy", specifier = ">=1.13.0" },
     { name = "pre-commit", specifier = ">=4.0.1" },
@@ -1532,6 +1636,7 @@ dev = [
     { name = "pyright", specifier = ">=1.1.392.post0" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
+    { name = "pytest-order", specifier = ">=1.3.0" },
     { name = "pytest-qt", specifier = ">=4.4.0" },
     { name = "rich", specifier = ">=13.9.4" },
     { name = "ruff", specifier = ">=0.8.3" },
@@ -1540,6 +1645,13 @@ dev = [
     { name = "types-pygments", specifier = ">=2.19.0.20250107" },
     { name = "types-pyinstaller", specifier = ">=6.11.0.20241028" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20241230" },
+]
+test = [
+    { name = "pyautogui", specifier = ">=0.9.54" },
+    { name = "pytest", specifier = ">=8.3.4" },
+    { name = "pytest-cov", specifier = ">=6.0.0" },
+    { name = "pytest-order", specifier = ">=1.3.0" },
+    { name = "pytest-qt", specifier = ">=4.4.0" },
 ]
 
 [[package]]
@@ -1780,6 +1892,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/25/69/5f1e57f6c5a39f81411b550027bf72842c4567ff5fd572bed1edc9e4b5d9/pytest_cov-6.1.1.tar.gz", hash = "sha256:46935f7aaefba760e716c2ebfbe1c216240b9592966e7da99ea8292d4d3e2a0a", size = 66857 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/28/d0/def53b4a790cfb21483016430ed828f64830dd981ebe1089971cd10cab25/pytest_cov-6.1.1-py3-none-any.whl", hash = "sha256:bddf29ed2d0ab6f4df17b4c55b0a657287db8684af9c42ea546b21b1041b3dde", size = 23841 },
+]
+
+[[package]]
+name = "pytest-order"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/66/02ae17461b14a52ce5a29ae2900156b9110d1de34721ccc16ccd79419876/pytest_order-1.3.0.tar.gz", hash = "sha256:51608fec3d3ee9c0adaea94daa124a5c4c1d2bb99b00269f098f414307f23dde", size = 47544 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/73/59b038d1aafca89f8e9936eaa8ffa6bb6138d00459d13a32ce070be4f280/pytest_order-1.3.0-py3-none-any.whl", hash = "sha256:2cd562a21380345dd8d5774aa5fd38b7849b6ee7397ca5f6999bbe6e89f07f6e", size = 14609 },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR would enable end-users to contribute widgets or other CoreActions to the gui by creating an instance of `WidgetActionInfo` prior to MainWindow creation.  For example:

```python
from pymmcore_gui import create_mmgui
from pymmcore_gui.actions import WidgetActionInfo
from PyQt6.QtWidgets import QWidget


def create_my_widget(parent: QWidget) -> QWidget:
    wdg = QWidget(parent)
    wdg.setStyleSheet("background-color: lightblue;")
    return wdg

WidgetActionInfo(
    key="mywidget",
    text="My Widget!!!!",
    icon="mdi-light:format-list-bulleted",
    create_widget=create_my_widget,
)

create_mmgui()
```

This is a step towards extensibility of the GUI
