### PR TITLE
feat: set icons to text color

### DIFF
--- a/src/pymmcore_gui/actions/_core_qaction.py
+++ b/src/pymmcore_gui/actions/_core_qaction.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from PyQt6.QtGui import QAction, QIcon
+from PyQt6.QtGui import QAction, QIcon, QPalette
+from PyQt6.QtWidgets import QApplication
 from superqt import QIconifyIcon
 from zmq import Enum
 
@@ -52,7 +53,8 @@ class QCoreAction(QAction):
             self.setEnabled(info.enabled)
         if info.icon is not None:
             if isinstance(info.icon, str):
-                icon: QIcon = QIconifyIcon(info.icon)
+                color = QApplication.palette().color(QPalette.ColorRole.WindowText)
+                icon: QIcon = QIconifyIcon(info.icon, color=color.name())
             else:
                 icon = QIcon(info.icon)
             self.setIcon(icon)


### PR DESCRIPTION
Now they can be seen with a dark theme!
![image](https://github.com/user-attachments/assets/6bb78f55-c906-4433-94d0-4ec8a1d3c05d)

For reference, here's how it looked before:
![image](https://github.com/user-attachments/assets/b50432a6-afc1-4878-b877-2d2bf44f6351)
