### PR TITLE
fix: QCoreAction: avoid QAction mnemonics

### DIFF
--- a/src/pymmcore_gui/actions/_core_qaction.py
+++ b/src/pymmcore_gui/actions/_core_qaction.py
@@ -42,7 +42,8 @@ class QCoreAction(QAction):
         if not (text := info.text):
             text = info.key.value if isinstance(info.key, Enum) else info.key
 
-        self.setText(text)
+        # Avoid mnemonics - use the shortcuts below instead.
+        self.setText(text.replace("&", "&&"))
         if info.auto_repeat is not None:
             self.setAutoRepeat(info.auto_repeat)
         if info.checkable is not None:


### PR DESCRIPTION
I have been working on a couple dedicated widgets for Becker & Hickl devices. I want Becker & Hickl / B&H to appear in the WidgetActionInfo text.

Since we already have the shortcut field on WidgetActionInfo, I think it's best to disable shortcuts within the QAction text by escaping the ampersands.