### PR TITLE
fix: Disable Snap/Live when camera unavailable

### DIFF
--- a/src/pymmcore_gui/actions/core_actions.py
+++ b/src/pymmcore_gui/actions/core_actions.py
@@ -38,8 +38,24 @@ def toggle_live(action: QCoreAction, checked: bool) -> None:
         mmc.startContinuousSequenceAcquisition(0)
 
 
+def _init_snap_image(action: QCoreAction) -> None:
+    mmc = action.mmc
+
+    def _on_load() -> None:
+        action.setEnabled(bool(mmc.getCameraDevice()))
+
+    mmc.events.systemConfigurationLoaded.connect(_on_load)
+
+    _on_load()
+
+
 def _init_toggle_live(action: QCoreAction) -> None:
     mmc = action.mmc
+
+    def _on_load() -> None:
+        action.setEnabled(bool(mmc.getCameraDevice()))
+
+    mmc.events.systemConfigurationLoaded.connect(_on_load)
 
     def _on_change() -> None:
         action.setChecked(mmc.isSequenceRunning())
@@ -47,6 +63,8 @@ def _init_toggle_live(action: QCoreAction) -> None:
     mmc.events.sequenceAcquisitionStarted.connect(_on_change)
     mmc.events.continuousSequenceAcquisitionStarted.connect(_on_change)
     mmc.events.sequenceAcquisitionStopped.connect(_on_change)
+
+    _on_load()
 
 
 def load_demo_config(action: QCoreAction, checked: bool) -> None:
@@ -64,6 +82,7 @@ snap_action = ActionInfo(
     auto_repeat=True,
     icon="mdi-light:camera",
     on_triggered=snap_image,
+    on_created=_init_snap_image,
 )
 
 


### PR DESCRIPTION
I kept trying to press Snap/Live without remembering to load a config file. This PR disables those buttons if you don't have a camera.

This is something that we do with the Snap Button and Live Button in pymmcore-widgets. Ideally, we'd just use those buttons, but since we aren't doing that now, this change solves the problem.