### PR TITLE
feat: device menu

### DIFF
--- a/src/pymmcore_gui/_main_window.py
+++ b/src/pymmcore_gui/_main_window.py
@@ -95,10 +95,24 @@ MenuDictValue = list[str] | Callable[[CMMCorePlus, "MicroManagerGUI"], QMenu]
 
 
 def _create_window_menu(mmc: CMMCorePlus, parent: MicroManagerGUI) -> QMenu:
-    """Create the Window menu."""
+    """
+    Create the Window menu, containing all WidgetActions not in other menus.
+
+    This function assumes lazy evaluation, i.e. that all Actions that want to be on
+    other menus are already there.
+    """
+    all_actions = set(ActionInfo.widget_actions())
+
+    # Ignore those already in other menus
+    parented_actions: set[str] = set()
+    for other_menu in parent.MENUS.values():
+        if isinstance(other_menu, list):
+            parented_actions.update(str(action) for action in other_menu)
+    parentless_actions = all_actions - parented_actions
+
+    # Create a new menu with the remaining parentless actions
     menu = QMenu(Menu.WINDOW.value, parent)
-    actions = sorted(ActionInfo.widget_actions())
-    for action in actions:
+    for action in sorted(parentless_actions):
         menu.addAction(parent.get_action(action))
     return menu
 

--- a/src/pymmcore_gui/_main_window.py
+++ b/src/pymmcore_gui/_main_window.py
@@ -143,9 +143,11 @@ class MicroManagerGUI(QMainWindow):
         Menu.PYMM_GUI: [WidgetAction.ABOUT],
         Menu.WINDOW: _create_window_menu,
         Menu.DEVICE: [
-            WidgetAction.CONFIG_WIZARD,
+            WidgetAction.PROP_BROWSER,
             WidgetAction.LOAD_CONFIG,
+            WidgetAction.CONFIG_WIZARD,
             WidgetAction.SAVE_CONFIG,
+            WidgetAction.INSTALL_DEVICES,
         ],
         Menu.HELP: [CoreAction.LOAD_DEMO],
     }

--- a/src/pymmcore_gui/_main_window.py
+++ b/src/pymmcore_gui/_main_window.py
@@ -71,7 +71,7 @@ class Menu(str, Enum):
 
     PYMM_GUI = "pymmcore-gui"
     WINDOW = "Window"
-    DEVICE = "Device"
+    DEVICE = "Devices"
     HELP = "Help"
 
     def __str__(self) -> str:

--- a/src/pymmcore_gui/_main_window.py
+++ b/src/pymmcore_gui/_main_window.py
@@ -71,6 +71,7 @@ class Menu(str, Enum):
 
     PYMM_GUI = "pymmcore-gui"
     WINDOW = "Window"
+    DEVICE = "Device"
     HELP = "Help"
 
     def __str__(self) -> str:
@@ -127,6 +128,11 @@ class MicroManagerGUI(QMainWindow):
     MENUS: Mapping[str, MenuDictValue] = {
         Menu.PYMM_GUI: [WidgetAction.ABOUT],
         Menu.WINDOW: _create_window_menu,
+        Menu.DEVICE: [
+            WidgetAction.CONFIG_WIZARD,
+            WidgetAction.LOAD_CONFIG,
+            WidgetAction.SAVE_CONFIG,
+        ],
         Menu.HELP: [CoreAction.LOAD_DEMO],
     }
 

--- a/src/pymmcore_gui/actions/widget_actions.py
+++ b/src/pymmcore_gui/actions/widget_actions.py
@@ -194,7 +194,7 @@ def create_about_widget(parent: QWidget) -> QWidget:
 
 show_about = WidgetActionInfo(
     key=WidgetAction.ABOUT,
-    text="About Pymmcore Gui",
+    text="About Pymmcore Gui...",
     create_widget=create_about_widget,
     dock_area=None,
     checkable=False,
@@ -213,7 +213,7 @@ show_console = WidgetActionInfo(
 
 show_property_browser = WidgetActionInfo(
     key=WidgetAction.PROP_BROWSER,
-    text="Property Browser",
+    text="Device Property Browser...",
     shortcut="Ctrl+Shift+P",
     icon="mdi-light:format-list-bulleted",
     create_widget=create_property_browser,
@@ -222,7 +222,7 @@ show_property_browser = WidgetActionInfo(
 
 show_install_devices = WidgetActionInfo(
     key=WidgetAction.INSTALL_DEVICES,
-    text="Install Devices",
+    text="Install Devices...",
     shortcut="Ctrl+Shift+I",
     icon="mdi-light:download",
     create_widget=create_install_widgets,
@@ -286,7 +286,7 @@ show_stage_control = WidgetActionInfo(
 
 show_config_wizard = WidgetActionInfo(
     key=WidgetAction.CONFIG_WIZARD,
-    text="Hardware Config Wizard",
+    text="Hardware Config Wizard...",
     icon="mdi:cog",
     create_widget=create_config_wizard,
     dock_area=None,
@@ -295,7 +295,7 @@ show_config_wizard = WidgetActionInfo(
 
 load_config = WidgetActionInfo(
     key=WidgetAction.LOAD_CONFIG,
-    text="Load Configuration File",
+    text="Load Configuration File...",
     icon="mdi:content-save",
     create_widget=create_load_config,
     dock_area=None,
@@ -304,7 +304,7 @@ load_config = WidgetActionInfo(
 
 save_config = WidgetActionInfo(
     key=WidgetAction.SAVE_CONFIG,
-    text="Save Configuration File",
+    text="Save Configuration File...",
     icon="mdi:content-save",
     create_widget=create_save_config,
     dock_area=None,

--- a/src/pymmcore_gui/actions/widget_actions.py
+++ b/src/pymmcore_gui/actions/widget_actions.py
@@ -45,6 +45,31 @@ class WidgetAction(ActionKey):
     SAVE_CONFIG = "pymmcore_gui.save_config_file"
 
 
+# ######################## Widget classes #########################
+
+
+class _LoadConfigDialog(QFileDialog):
+    def exec(self) -> int:
+        (filename, _) = super().getOpenFileName(
+            None, "Select a Micro-Manager configuration file", "", "cfg(*.cfg)"
+        )
+        if filename:
+            mmc = _get_core(cast("QWidget", self.parent())) or CMMCorePlus.instance()
+            mmc.loadSystemConfiguration(filename)
+        return 1 if filename else 0
+
+
+class _SaveConfigDialog(QFileDialog):
+    def exec(self) -> int:
+        (filename, _) = super().getSaveFileName(
+            None, "Save current Micro-Manager configuration", "", "cfg(*.cfg)"
+        )
+        if filename:
+            mmc = _get_core(cast("QWidget", self.parent())) or CMMCorePlus.instance()
+            mmc.saveSystemConfiguration(filename)
+        return 1 if filename else 0
+
+
 # ######################## Functions that create widgets #########################
 
 
@@ -93,35 +118,12 @@ def create_install_widgets(parent: QWidget) -> pmmw.InstallWidget:
 
 def create_load_config(parent: QWidget) -> QDialog:
     """Open file dialog to select a config file."""
-
-    class LoadConfigDialog(QFileDialog):
-        def exec(self) -> int:
-            (filename, _) = super().getOpenFileName(
-                None, "Select a Micro-Manager configuration file", "", "cfg(*.cfg)"
-            )
-            if filename:
-                mmc = _get_core(parent) or CMMCorePlus.instance()
-                mmc.unloadAllDevices()
-                mmc.loadSystemConfiguration(filename)
-            return 1 if filename else 0
-
-    return LoadConfigDialog(parent=parent)
+    return _LoadConfigDialog(parent=parent)
 
 
 def create_save_config(parent: QWidget) -> QDialog:
     """Open file dialog to select a config file."""
-
-    class SaveConfigDialog(QFileDialog):
-        def exec(self) -> int:
-            (filename, _) = super().getSaveFileName(
-                None, "Save current Micro-Manager configuration", "", "cfg(*.cfg)"
-            )
-            if filename:
-                mmc = _get_core(parent) or CMMCorePlus.instance()
-                mmc.saveSystemConfiguration(filename)
-            return 1 if filename else 0
-
-    return SaveConfigDialog(parent=parent)
+    return _SaveConfigDialog(parent=parent)
 
 
 def create_mda_widget(parent: QWidget) -> pmmw.MDAWidget:

--- a/src/pymmcore_gui/actions/widget_actions.py
+++ b/src/pymmcore_gui/actions/widget_actions.py
@@ -49,25 +49,39 @@ class WidgetAction(ActionKey):
 
 
 class _LoadConfigDialog(QFileDialog):
-    def exec(self) -> int:
-        (filename, _) = super().getOpenFileName(
-            None, "Select a Micro-Manager configuration file", "", "cfg(*.cfg)"
-        )
-        if filename:
+    def __init__(self, parent: QWidget) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Select a Micro-Manager configuration file")
+        self.setNameFilter("cfg(*.cfg)")
+        self.setFileMode(QFileDialog.FileMode.ExistingFile)
+        self.setAcceptMode(QFileDialog.AcceptMode.AcceptOpen)
+
+        self.accepted.connect(self._load_config)
+
+    def _load_config(self) -> None:
+        selected_files = self.selectedFiles()
+        if selected_files:
+            filename = selected_files[0]
             mmc = _get_core(cast("QWidget", self.parent())) or CMMCorePlus.instance()
             mmc.loadSystemConfiguration(filename)
-        return 1 if filename else 0
 
 
 class _SaveConfigDialog(QFileDialog):
-    def exec(self) -> int:
-        (filename, _) = super().getSaveFileName(
-            None, "Save current Micro-Manager configuration", "", "cfg(*.cfg)"
-        )
-        if filename:
+    def __init__(self, parent: QWidget) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Save current Micro-Manager configuration")
+        self.setNameFilter("cfg(*.cfg)")
+        self.setFileMode(QFileDialog.FileMode.AnyFile)
+        self.setAcceptMode(QFileDialog.AcceptMode.AcceptSave)
+
+        self.accepted.connect(self._save_config)
+
+    def _save_config(self) -> None:
+        selected_files = self.selectedFiles()
+        if selected_files:
+            filename = selected_files[0]
             mmc = _get_core(cast("QWidget", self.parent())) or CMMCorePlus.instance()
             mmc.saveSystemConfiguration(filename)
-        return 1 if filename else 0
 
 
 # ######################## Functions that create widgets #########################


### PR DESCRIPTION
We need an intuitive way to load and save configuration files. Right now, the only option provided by the GUI is the buttons on the GroupPresetTableWidget, which might not be open.

This PR provides a solution using a new Menu (titled "Device"), aligning with the existing mmstudio solution. It also moves the Hardware Configuration Wizard into this menu.