### PR TITLE
fix: pre-load MSVC DLLs to block old versions

### DIFF
--- a/src/pymmcore_gui/__init__.py
+++ b/src/pymmcore_gui/__init__.py
@@ -7,6 +7,43 @@ try:
 except PackageNotFoundError:
     __version__ = "uninstalled"
 
+import sys
+
+if sys.platform == "win32":
+    # On Windows, a DLL of a given basename is only loaded once per process.
+    # This can cause issues if one Python package (e.g. PyQt6) bundles and
+    # loads an old DLL and another, later-imported package (e.g. pymmcore or a
+    # device adapter) requires a newer version of the DLL. The symptom, if any,
+    # will likely be a crash (but could be e.g. silent memory corruption).
+    # Most often this happens with Microsoft Visual C++ Runtime DLLs, because
+    # all C++ code depends on them. Here we preemptively load a (heuristically
+    # chosen) subset of these DLLs so that we load the system-installed
+    # versions, which are most likely to be up to date.
+    # Note 1: We are relying on the fact that the Micro-Manager installer
+    # (among other things) installs the Visual C++ Redistributables (vc_redist)
+    # package onto the system, and the fact that these DLLs are designed to be
+    # backward-compatible.
+    # Note 2: The list of DLLs loaded below cover all that are used by pymmcore
+    # and the device adapters at the time of writing and/or are bundled by
+    # PyQt6. The full list is at
+    # https://learn.microsoft.com/en-us/cpp/windows/determining-which-dlls-to-redistribute
+    # but we do not want to load the DLLs that will never be used.
+    # Note 3: In fact the Python interpreter itself bundles vcruntime140.dll
+    # and vcruntime140_1.dll; but these are usually new enough if using the
+    # latest Python versions.
+    import ctypes
+
+    msvc_runtimes = [
+        "concrt140",
+        "msvcp140",
+        "msvcp140_1",
+        "msvcp140_2",
+        "vcruntime140",
+        "vcruntime140_1",
+    ]
+    for dll in msvc_runtimes:
+        ctypes.WinDLL(dll)
+
 from ._app import create_mmgui
 from ._main_window import MicroManagerGUI
 from .actions import ActionInfo, CoreAction, WidgetAction

--- a/src/pymmcore_gui/__init__.py
+++ b/src/pymmcore_gui/__init__.py
@@ -31,6 +31,7 @@ if sys.platform == "win32":
     # Note 3: In fact the Python interpreter itself bundles vcruntime140.dll
     # and vcruntime140_1.dll; but these are usually new enough if using the
     # latest Python versions.
+    import contextlib
     import ctypes
 
     msvc_runtimes = [
@@ -42,7 +43,8 @@ if sys.platform == "win32":
         "vcruntime140_1",
     ]
     for dll in msvc_runtimes:
-        ctypes.WinDLL(dll)
+        with contextlib.suppress(OSError):
+            ctypes.WinDLL(dll)
 
 from ._app import create_mmgui
 from ._main_window import MicroManagerGUI


### PR DESCRIPTION
Before importing any third-party packages, load these DLLs from the system-installed copies (or copies bundled by the Python interpreter in the case of `vcruntime140[_1].dll`).

Closes #91.

Another way to do this would be to put this code in pymmcore-plus (where we can document that it needs to be imported before certain packages such as PyQt), and import pymmcore_plus before everything else.

Some additional details:

Currently, pymmcore and Micro-Manager device adapters use concrt140, msvcp140, vcruntime140, and vcruntime140_1. The Micro-Manager installer installs vc_redist 14.42.34438.0 at the moment.

As mentioned in the comment, CPython bundles vcruntime140 and vcruntime140_1. Python.org Python 3.12.10 and 3.13.5 bundle 14.42.34438.0; 3.11.9 bundles 14.38.33126; and 3.9.13 and 3.10.11 bundle 14.29.30139. These cannot be replaced, so if they ever cause problems, the solution will be to upgrade to the latest Python. Python installed from `uv` (3.11-13) bundles 14.42.34433.0.

PyQt6 bundles concrt140, msvcp140, msvcp140_1, msvcp140_2, vcruntime140, and vcruntime140_1. I felt it would be good to include msvcp140_1 and msvcp140_2 in the pre-loaded list even though they are not needed by device adapters, because device adapters may use them in the future and also because it feels bad to not have their versions match msvcp140.