### PR TITLE
fix: set environment variable for Qt backend signals

### DIFF
--- a/src/pymmcore_gui/__init__.py
+++ b/src/pymmcore_gui/__init__.py
@@ -1,5 +1,7 @@
 """A Micro-Manager GUI based on pymmcore-widgets and pymmcore-plus."""
 
+import os
+import sys
 from importlib.metadata import PackageNotFoundError, version
 
 try:
@@ -7,7 +9,9 @@ try:
 except PackageNotFoundError:
     __version__ = "uninstalled"
 
-import sys
+# to avoid https://github.com/pymmcore-plus/pymmcore-gui/issues/114
+# set this env var to instruct pymmcore-plus to use the Qt backend for signals
+os.environ.setdefault("PYMM_SIGNALS_BACKEND", "qt")
 
 if sys.platform == "win32":
     # On Windows, a DLL of a given basename is only loaded once per process.


### PR DESCRIPTION
closes #114 

pymmcore-gui will now run `os.environ.setdefault("PYMM_SIGNALS_BACKEND", "qt")` on import, instructing pymmcore-plus to use Qt-backed signals when instantiating a Core, even if no Qt application has started yet.

the reason this hasn't been necessary is that `create_mmgui` itself creates a QApplication before instantiating a core object, and pymmcore-plus will use Qt signals if a QApplication has been created... but in cases where a user wants to instantiate the core first, this little fix gives pymmcore-plus a "head up" that gui usage is coming up