### PR TITLE
fix: disable floating for StageExplorer to prevent OpenGL context errors

### DIFF
--- a/src/pymmcore_gui/_main_window.py
+++ b/src/pymmcore_gui/_main_window.py
@@ -344,6 +344,10 @@ class MicroManagerGUI(QMainWindow):
             dock.setMinimumSize(widget.minimumSize())
             dock.setIcon(action.icon())
             dock.resize(widget.sizeHint())
+            if not info.floatable:
+                dock.setFeature(
+                    CDockWidget.DockWidgetFeature.DockWidgetFloatable, False
+                )
             self._dock_widgets[key] = dock
             if area is None:
                 self.dock_manager.addDockWidgetFloating(dock)

--- a/src/pymmcore_gui/actions/_action_info.py
+++ b/src/pymmcore_gui/actions/_action_info.py
@@ -140,3 +140,4 @@ class WidgetActionInfo(ActionInfo):
         DockWidgetArea.RightDockWidgetArea
     )
     scroll_mode: CDockWidget.eInsertMode = CDockWidget.eInsertMode.AutoScrollArea
+    floatable: bool = True

--- a/src/pymmcore_gui/actions/widget_actions.py
+++ b/src/pymmcore_gui/actions/widget_actions.py
@@ -280,4 +280,5 @@ stage_explorer_widget = WidgetActionInfo(
     icon="mdi:map-search",
     create_widget=create_stage_explorer_widget,
     dock_area=DockWidgetArea.LeftDockWidgetArea,
+    floatable=False,
 )


### PR DESCRIPTION
Undocking the `StageExplorer` widget causes `OpenGL` context invalidation because `Qt` destroys and recreates the `GL` context when reparenting the `vispy` `SceneCanvas` to a new floating window. On Windows this crashes the app.

With this PR we add a floatable field to `WidgetActionInfo` and set it to `False` for the `StageExplorer`, preventing it from being undocked (we can only change its position within the dockable area). This matches the existing approach used for `ndv` viewers.

