### PR TITLE
fix: drain live preview buffer

### DIFF
--- a/src/pymmcore_gui/widgets/image_preview/_ndv_preview.py
+++ b/src/pymmcore_gui/widgets/image_preview/_ndv_preview.py
@@ -13,7 +13,9 @@ if TYPE_CHECKING:
     from pymmcore_plus import CMMCorePlus
 
 
-BUFFER_SIZE = 100
+# Live preview only needs the most recent frame. Keep the local viewer buffer
+# tiny to avoid large memory usage on high-resolution cameras.
+BUFFER_SIZE = 1
 
 
 class NDVPreview(ImagePreviewBase):

--- a/src/pymmcore_gui/widgets/image_preview/_preview_base.py
+++ b/src/pymmcore_gui/widgets/image_preview/_preview_base.py
@@ -82,8 +82,11 @@ class ImagePreviewBase(QWidget):
     def timerEvent(self, a0: QTimerEvent) -> None:
         if (core := self._mmc) and core.getRemainingImageCount() > 0:
             try:
-                img = core.fixImage(core.getLastImage())
-                self.append(img)
+                latest = None
+                while core.getRemainingImageCount() > 0:
+                    latest = core.popNextImage()
+                if latest is not None:
+                    self.append(latest)
             except Exception as e:
                 warnings.warn(
                     f"Failed to get image from core: {e}", RuntimeWarning, stacklevel=2


### PR DESCRIPTION
## Summary

This keeps the live image preview from accumulating stale frames during continuous acquisition:

- drain the Micro-Manager live-preview queue on each timer tick
- display only the most recent frame
- reduce the local NDV live-preview ring buffer to one frame

## Background

This came from testing pymmcore-gui on a Nikon TiEclipse setup with a high-resolution camera, where the live preview could lag and the viewer buffer could grow unnecessarily for a workflow that only needs the latest live frame.

## Validation

- python -m ruff check src/pymmcore_gui/widgets/image_preview/_preview_base.py src/pymmcore_gui/widgets/image_preview/_ndv_preview.py
- python -m compileall -q src/pymmcore_gui/widgets/image_preview/_preview_base.py src/pymmcore_gui/widgets/image_preview/_ndv_preview.py