### PR TITLE
feat: add experimental MDA position map widget

### DIFF
--- a/MDA_POSITION_MAP_DESIGN.md
+++ b/MDA_POSITION_MAP_DESIGN.md
@@ -1,0 +1,265 @@
+# MDA Position Map - Note de conception
+
+## Objectif
+
+Ajouter a `pymmcore-gui` un widget de type carte 2D qui :
+
+- affiche les positions XY definies dans le MDA ;
+- represente pour chaque position le champ observe sous forme de rectangle ;
+- aide l'utilisateur a se reperer spatialement entre les positions ;
+- permette a terme de cliquer sur une position pour y deplacer la platine ;
+- reste synchronise avec la table de positions du MDA.
+
+Le besoin n'est pas de remplacer `Stage Explorer`, mais de completer le workflow MDA avec une vue synoptique des positions.
+
+## Positionnement par rapport a `Stage Explorer`
+
+`Stage Explorer` sait deja :
+
+- afficher la FOV courante ;
+- deplacer la platine ;
+- dessiner des ROIs ;
+- generer un `grid_plan` et lancer un MDA a partir d'une ROI.
+
+Mais il ne consomme pas nativement la liste des positions du MDA.
+
+Le nouveau widget doit donc etre pense comme :
+
+- soit un nouveau widget dedie, par exemple `MDA Position Map`
+- soit une extension reutilisant des briques de `Stage Explorer`
+
+La solution la plus propre semble etre un nouveau widget specialise MDA, qui pourra ensuite partager certaines briques avec `Stage Explorer`.
+
+## MVP recommande
+
+Version minimale utile :
+
+- lire les positions XY de la sequence MDA courante ;
+- calculer la largeur et la hauteur de FOV ;
+- dessiner un rectangle par position ;
+- afficher un index ou un nom de position ;
+- surligner la position selectionnee dans la table ;
+- mettre a jour la carte quand la table change.
+
+Pas besoin au debut de :
+
+- dessiner les images acquises ;
+- gerer les ROIs libres ;
+- gerer la 3D ;
+- introduire des modeles complexes de calibration.
+
+## Source de verite
+
+La source de verite des positions doit rester la sequence MDA et son editeur de positions.
+
+En pratique :
+
+- la table des positions MDA reste la representation autoritaire ;
+- la carte n'est pas la source principale des donnees ;
+- la carte est d'abord une vue synchronisee, puis un moyen d'interaction secondaire.
+
+Cela evite :
+
+- d'avoir deux listes de positions concurrentes ;
+- de creer des divergences entre la table et la carte ;
+- de compliquer la serialisation du MDA.
+
+## Implementation prevue pour l'enregistrement des positions
+
+Le point important est de definir tres clairement comment les positions sont creees et mises a jour.
+
+### Principe general
+
+L'enregistrement des positions doit rester rattache au workflow MDA existant.
+
+Le widget de carte ne doit pas stocker sa propre liste persistante independante. Il doit :
+
+- lire les positions depuis le modele MDA ;
+- proposer des actions utilisateur ;
+- deleguer ensuite l'ecriture au widget ou au modele de positions du MDA.
+
+### Actions a prevoir
+
+#### 1. Ajouter la position courante
+
+Action utilisateur :
+
+- bouton `Ajouter position courante`
+
+Effet attendu :
+
+- lire `x` et `y` depuis la platine XY courante ;
+- lire `z` si le MDA inclut Z ou si la table de positions inclut un Z explicite ;
+- creer une nouvelle entree de position dans la table MDA ;
+- rafraichir la carte.
+
+Usage :
+
+- l'utilisateur se deplace a la platine ;
+- clique sur `Ajouter position courante` ;
+- voit apparaitre un nouveau rectangle sur la carte.
+
+#### 2. Mettre a jour la position selectionnee
+
+Action utilisateur :
+
+- bouton `Remplacer par position courante`
+
+Effet attendu :
+
+- lire la ligne selectionnee dans la table MDA ;
+- remplacer ses coordonnees XY par la position courante de la platine ;
+- optionnellement remplacer Z selon le mode choisi ;
+- rafraichir la carte.
+
+Usage :
+
+- corriger une position deja definie sans devoir la supprimer puis la recreer.
+
+#### 3. Supprimer la position selectionnee
+
+Action utilisateur :
+
+- suppression depuis la table MDA, ou depuis la carte si une position est selectionnee
+
+Effet attendu :
+
+- suppression dans le modele MDA ;
+- la carte suit automatiquement.
+
+#### 4. Selection bidirectionnelle
+
+Effet attendu :
+
+- clic dans la table -> surbrillance sur la carte
+- clic sur un rectangle de la carte -> selection de la ligne correspondante
+
+Cela est essentiel pour rendre la carte utile au quotidien.
+
+### Ce qu'il ne faut pas faire au debut
+
+Pour le MVP, il vaut mieux eviter :
+
+- edition libre des rectangles par drag-and-drop
+- stockage d'une liste parallele locale au widget
+- formats de sauvegarde specifiques a la carte
+
+Ces fonctions sont possibles plus tard, mais elles compliquent beaucoup la coherence avec le MDA.
+
+## Calcul de la taille des rectangles
+
+Le rectangle ne doit pas etre derive uniquement d'un grossissement saisi a la main.
+
+La priorite doit etre :
+
+1. calibration effective du core
+2. taille d'image effective
+3. ROI camera
+4. binning courant
+
+Calcul vise :
+
+- `fov_width_um = image_width_px * pixel_size_um`
+- `fov_height_um = image_height_px * pixel_size_um`
+
+Le widget doit si possible utiliser :
+
+- `getPixelSizeUm()`
+- `getImageWidth()`
+- `getImageHeight()`
+
+et ensuite tenir compte des changements de ROI et de binning si ceux-ci modifient la taille image ou la calibration effective.
+
+## Synchronisation envisagee avec le MDA
+
+Le plus probable est que le widget doive s'accrocher a l'objet ou au modele utilise par `MDAWidget`.
+
+Synchronisations souhaitees :
+
+- changement de sequence MDA
+- ajout/suppression/modification de positions
+- changement de selection dans la table
+- eventuellement progression de l'acquisition multi-position
+
+L'ideal est d'eviter toute logique de polling si une connexion par signaux est possible.
+
+## Architecture proposee
+
+### Option A : nouveau widget dedie
+
+Exemple de nom :
+
+- `MDAPositionMapWidget`
+
+Responsabilites :
+
+- afficher la carte ;
+- connaitre la FOV courante ;
+- synchroniser la selection ;
+- deleguer les operations d'ajout/modification/suppression au modele MDA.
+
+Avantage :
+
+- claire separation des responsabilites ;
+- plus simple a proposer upstream.
+
+### Option B : extension de `Stage Explorer`
+
+Cette option consisterait a reutiliser directement `Stage Explorer` comme support principal.
+
+Avantage :
+
+- reutilisation de la scene 2D existante ;
+- reutilisation du rendu de FOV et de certaines interactions.
+
+Inconvenient :
+
+- risque de melanger deux usages differents :
+  - exploration libre / scan ROI
+  - edition et visualisation des positions MDA
+
+Pour l'instant, l'option A semble preferable.
+
+## Etapes de mise en oeuvre recommandees
+
+### Etape 1
+
+Prototype en lecture seule :
+
+- afficher les positions MDA existantes
+- afficher le rectangle de FOV
+- synchroniser la selection
+
+### Etape 2
+
+Ajout de l'enregistrement de positions :
+
+- `Ajouter position courante`
+- `Remplacer par position courante`
+- `Aller a la position selectionnee`
+
+### Etape 3
+
+Ameliorations de confort :
+
+- labels plus lisibles
+- position active pendant acquisition
+- options de style
+- prise en compte explicite du ROI et du binning
+
+## Questions a garder ouvertes
+
+- quel est l'objet exact a ecouter dans `MDAWidget` pour suivre les positions ?
+- faut-il prendre en charge le Z dans la carte, ou rester strictement en XY ?
+- comment gerer les inversions d'axes ou rotations si la calibration n'est pas triviale ?
+- faut-il afficher seulement le centre, ou toujours le rectangle complet ?
+
+## Position retenue
+
+Pour la suite du developpement :
+
+- le widget de carte doit etre un composant MDA, pas un simple outil ROI ;
+- l'enregistrement des positions doit rester pilote par le modele MDA ;
+- la carte doit etre une vue synchronisee et un support d'interaction, pas une base de donnees parallele ;
+- l'implementation du workflow d'enregistrement doit commencer par `Ajouter position courante` et `Remplacer par position courante`.
+

--- a/src/pymmcore_gui/actions/widget_actions.py
+++ b/src/pymmcore_gui/actions/widget_actions.py
@@ -206,7 +206,9 @@ def create_mda_position_map_widget(parent: QWidget) -> QWidget:
     if mmwin is None:  # pragma: no cover
         raise RuntimeError("MDA Position Map requires a MicroManagerGUI parent")
     mda_widget = mmwin.get_widget(WidgetAction.MDA_WIDGET)
-    return MDAPositionMapWidget(parent=parent, mmcore=_get_core(parent), mda_widget=mda_widget)
+    return MDAPositionMapWidget(
+        parent=parent, mmcore=_get_core(parent), mda_widget=mda_widget
+    )
 
 
 # ######################## WidgetAction Enum #########################

--- a/src/pymmcore_gui/actions/widget_actions.py
+++ b/src/pymmcore_gui/actions/widget_actions.py
@@ -43,6 +43,7 @@ class WidgetAction(ActionKey):
     EXCEPTION_LOG = "pymmcore_gui.exception_log"
     STAGE_CONTROL = "pymmcore_gui.stage_control_widget"
     STAGE_EXPLORER = "pymmcore_gui.stage_explorer_widget"
+    MDA_POSITION_MAP = "pymmcore_gui.mda_position_map_widget"
     CONFIG_WIZARD = "pymmcore_gui.hardware_config_wizard"
 
 
@@ -197,6 +198,17 @@ def create_stage_explorer_widget(parent: QWidget) -> pmmw.StageExplorer:
     return StageExplorer(parent=parent, mmcore=_get_core(parent))
 
 
+def create_mda_position_map_widget(parent: QWidget) -> QWidget:
+    """Create an experimental map of the MDA positions."""
+    from pymmcore_gui.widgets._mda_position_map import MDAPositionMapWidget
+
+    mmwin = _get_mm_main_window(parent)
+    if mmwin is None:  # pragma: no cover
+        raise RuntimeError("MDA Position Map requires a MicroManagerGUI parent")
+    mda_widget = mmwin.get_widget(WidgetAction.MDA_WIDGET)
+    return MDAPositionMapWidget(parent=parent, mmcore=_get_core(parent), mda_widget=mda_widget)
+
+
 # ######################## WidgetAction Enum #########################
 
 
@@ -318,4 +330,12 @@ stage_explorer_widget = WidgetActionInfo(
     create_widget=create_stage_explorer_widget,
     dock_area=DockWidgetArea.LeftDockWidgetArea,
     floatable=False,
+)
+
+mda_position_map_widget = WidgetActionInfo(
+    key=WidgetAction.MDA_POSITION_MAP,
+    text="MDA Position Map",
+    icon="mdi:map-marker-multiple-outline",
+    create_widget=create_mda_position_map_widget,
+    dock_area=DockWidgetArea.RightDockWidgetArea,
 )

--- a/src/pymmcore_gui/widgets/_mda_position_map.py
+++ b/src/pymmcore_gui/widgets/_mda_position_map.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
@@ -18,12 +17,13 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from useq import Position
 
 if TYPE_CHECKING:
-    from qtpy.QtCore import QItemSelection, QItemSelectionModel
+    from collections.abc import Sequence
 
     from pymmcore_widgets.mda._core_mda import MDAWidget
+    from qtpy.QtCore import QItemSelection
+    from useq import Position
 
 
 @dataclass(slots=True)
@@ -97,7 +97,9 @@ class MDAPositionMapWidget(QWidget):
         layout.addWidget(self._view, 1)
         layout.addWidget(self._status, 0)
 
-        self._position_items: dict[int, tuple[QGraphicsRectItem, QGraphicsSimpleTextItem]] = {}
+        self._position_items: dict[
+            int, tuple[QGraphicsRectItem, QGraphicsSimpleTextItem]
+        ] = {}
         self._selection_model: QItemSelectionModel | None = None
 
         self._mda_widget.valueChanged.connect(self.refresh)
@@ -144,8 +146,12 @@ class MDAPositionMapWidget(QWidget):
             self._position_items[footprint.row] = (rect_item, label_item)
 
         margin = max(footprints[0].width_um, footprints[0].height_um) * 0.5
-        self._scene.setSceneRect(self._scene.itemsBoundingRect().adjusted(-margin, -margin, margin, margin))
-        self._view.fitInView(self._scene.sceneRect(), Qt.AspectRatioMode.KeepAspectRatio)
+        self._scene.setSceneRect(
+            self._scene.itemsBoundingRect().adjusted(-margin, -margin, margin, margin)
+        )
+        self._view.fitInView(
+            self._scene.sceneRect(), Qt.AspectRatioMode.KeepAspectRatio
+        )
         self._update_selection_highlight()
 
     def _attach_selection_model(self) -> None:
@@ -155,7 +161,9 @@ class MDAPositionMapWidget(QWidget):
             return
         if self._selection_model is not None:
             try:
-                self._selection_model.selectionChanged.disconnect(self._on_selection_changed)
+                self._selection_model.selectionChanged.disconnect(
+                    self._on_selection_changed
+                )
             except (RuntimeError, TypeError):
                 pass
         self._selection_model = selection_model
@@ -210,7 +218,9 @@ class MDAPositionMapWidget(QWidget):
         model.select(idx, flags)
         table.setCurrentCell(row, 0)
 
-    def _on_selection_changed(self, _selected: QItemSelection, _deselected: QItemSelection) -> None:
+    def _on_selection_changed(
+        self, _selected: QItemSelection, _deselected: QItemSelection
+    ) -> None:
         self._update_selection_highlight()
 
     def _update_selection_highlight(self) -> None:

--- a/src/pymmcore_gui/widgets/_mda_position_map.py
+++ b/src/pymmcore_gui/widgets/_mda_position_map.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, cast
+
+from pymmcore_plus import CMMCorePlus
+from qtpy.QtCore import QItemSelectionModel, QRectF, Qt, Signal
+from qtpy.QtGui import QColor, QPainter, QPen
+from qtpy.QtWidgets import (
+    QFrame,
+    QGraphicsItem,
+    QGraphicsRectItem,
+    QGraphicsScene,
+    QGraphicsSimpleTextItem,
+    QGraphicsView,
+    QLabel,
+    QVBoxLayout,
+    QWidget,
+)
+from useq import Position
+
+if TYPE_CHECKING:
+    from qtpy.QtCore import QItemSelection, QItemSelectionModel
+
+    from pymmcore_widgets.mda._core_mda import MDAWidget
+
+
+@dataclass(slots=True)
+class PositionFootprint:
+    row: int
+    label: str
+    x_um: float
+    y_um: float
+    width_um: float
+    height_um: float
+
+
+class _MapView(QGraphicsView):
+    rectClicked = Signal(int)
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setFrameShape(QFrame.Shape.NoFrame)
+        self.setRenderHints(self.renderHints() | QPainter.RenderHint.Antialiasing)
+        self.setDragMode(QGraphicsView.DragMode.ScrollHandDrag)
+        self.setTransformationAnchor(QGraphicsView.ViewportAnchor.AnchorUnderMouse)
+        self.setResizeAnchor(QGraphicsView.ViewportAnchor.AnchorViewCenter)
+        self._rect_to_row: dict[QGraphicsItem, int] = {}
+
+    def clear_rect_mapping(self) -> None:
+        self._rect_to_row.clear()
+
+    def register_rect(self, item: QGraphicsItem, row: int) -> None:
+        self._rect_to_row[item] = row
+
+    def mousePressEvent(self, event) -> None:  # type: ignore[override]
+        if event.button() == Qt.MouseButton.LeftButton:
+            item = self.itemAt(event.position().toPoint())
+            while item is not None:
+                if item in self._rect_to_row:
+                    self.rectClicked.emit(self._rect_to_row[item])
+                    break
+                item = item.parentItem()
+        super().mousePressEvent(event)
+
+    def wheelEvent(self, event) -> None:  # type: ignore[override]
+        factor = 1.15 if event.angleDelta().y() > 0 else 1 / 1.15
+        self.scale(factor, factor)
+
+
+class MDAPositionMapWidget(QWidget):
+    """Experimental XY overview of positions currently defined in the MDA widget."""
+
+    def __init__(
+        self,
+        *,
+        mda_widget: MDAWidget,
+        mmcore: CMMCorePlus | None = None,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("MDA Position Map")
+
+        self._mmc = mmcore or CMMCorePlus.instance()
+        self._mda_widget = mda_widget
+        self._scene = QGraphicsScene(self)
+        self._view = _MapView(self)
+        self._view.setScene(self._scene)
+        self._view.rectClicked.connect(self._select_row)
+
+        self._status = QLabel(self)
+        self._status.setWordWrap(True)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self._view, 1)
+        layout.addWidget(self._status, 0)
+
+        self._position_items: dict[int, tuple[QGraphicsRectItem, QGraphicsSimpleTextItem]] = {}
+        self._selection_model: QItemSelectionModel | None = None
+
+        self._mda_widget.valueChanged.connect(self.refresh)
+        self._mmc.events.systemConfigurationLoaded.connect(self.refresh)
+        self._mmc.events.roiSet.connect(self.refresh)
+        self._mmc.events.pixelSizeChanged.connect(self.refresh)
+        self._attach_selection_model()
+        self.refresh()
+
+    def refresh(self) -> None:
+        self._attach_selection_model()
+        self._scene.clear()
+        self._view.clear_rect_mapping()
+        self._position_items.clear()
+
+        footprints = self._collect_footprints()
+        if not footprints:
+            self._status.setText("No MDA positions to display.")
+            return
+
+        self._status.setText(
+            f"{len(footprints)} position(s). FOV: {footprints[0].width_um:.1f} x {footprints[0].height_um:.1f} um"
+        )
+
+        for footprint in footprints:
+            rect = QRectF(
+                footprint.x_um - footprint.width_um / 2,
+                footprint.y_um - footprint.height_um / 2,
+                footprint.width_um,
+                footprint.height_um,
+            )
+            rect_item = QGraphicsRectItem(rect)
+            rect_item.setPen(QPen(QColor("#2F7D32"), 2))
+            rect_item.setBrush(QColor(47, 125, 50, 35))
+            rect_item.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsSelectable, True)
+            self._scene.addItem(rect_item)
+            self._view.register_rect(rect_item, footprint.row)
+
+            label_item = QGraphicsSimpleTextItem(footprint.label)
+            label_item.setBrush(QColor("#1F2937"))
+            label_item.setPos(rect.left() + 8, rect.top() + 8)
+            self._scene.addItem(label_item)
+
+            self._position_items[footprint.row] = (rect_item, label_item)
+
+        margin = max(footprints[0].width_um, footprints[0].height_um) * 0.5
+        self._scene.setSceneRect(self._scene.itemsBoundingRect().adjusted(-margin, -margin, margin, margin))
+        self._view.fitInView(self._scene.sceneRect(), Qt.AspectRatioMode.KeepAspectRatio)
+        self._update_selection_highlight()
+
+    def _attach_selection_model(self) -> None:
+        table = self._mda_widget.stage_positions.table()
+        selection_model = table.selectionModel()
+        if selection_model is self._selection_model or selection_model is None:
+            return
+        if self._selection_model is not None:
+            try:
+                self._selection_model.selectionChanged.disconnect(self._on_selection_changed)
+            except (RuntimeError, TypeError):
+                pass
+        self._selection_model = selection_model
+        self._selection_model.selectionChanged.connect(self._on_selection_changed)
+
+    def _collect_footprints(self) -> list[PositionFootprint]:
+        positions = cast(
+            "Sequence[Position]",
+            self._mda_widget.stage_positions.value(
+                exclude_unchecked=False, exclude_hidden_cols=True
+            ),
+        )
+        width_um, height_um = self._fov_size_um()
+        footprints: list[PositionFootprint] = []
+        for row, pos in enumerate(positions):
+            if pos.x is None or pos.y is None:
+                continue
+            footprints.append(
+                PositionFootprint(
+                    row=row,
+                    label=pos.name or f"P{row + 1}",
+                    x_um=pos.x,
+                    y_um=pos.y,
+                    width_um=width_um,
+                    height_um=height_um,
+                )
+            )
+        return footprints
+
+    def _fov_size_um(self) -> tuple[float, float]:
+        px = self._mmc.getPixelSizeUm()
+        if px <= 0:
+            px = 1.0
+        return self._mmc.getImageWidth() * px, self._mmc.getImageHeight() * px
+
+    def _selected_rows(self) -> set[int]:
+        if self._selection_model is None:
+            return set()
+        return {index.row() for index in self._selection_model.selectedRows()}
+
+    def _select_row(self, row: int) -> None:
+        table = self._mda_widget.stage_positions.table()
+        model = table.selectionModel()
+        if model is None:
+            return
+        idx = table.model().index(row, 0)
+        flags = cast(
+            "QItemSelectionModel.SelectionFlags",
+            QItemSelectionModel.SelectionFlag.ClearAndSelect
+            | QItemSelectionModel.SelectionFlag.Rows,
+        )
+        model.select(idx, flags)
+        table.setCurrentCell(row, 0)
+
+    def _on_selection_changed(self, _selected: QItemSelection, _deselected: QItemSelection) -> None:
+        self._update_selection_highlight()
+
+    def _update_selection_highlight(self) -> None:
+        selected = self._selected_rows()
+        for row, (rect_item, label_item) in self._position_items.items():
+            if row in selected:
+                rect_item.setPen(QPen(QColor("#D9480F"), 3))
+                rect_item.setBrush(QColor(217, 72, 15, 60))
+                label_item.setBrush(QColor("#7C2D12"))
+            else:
+                rect_item.setPen(QPen(QColor("#2F7D32"), 2))
+                rect_item.setBrush(QColor(47, 125, 50, 35))
+                label_item.setBrush(QColor("#1F2937"))

--- a/src/pymmcore_gui/widgets/_mda_position_map.py
+++ b/src/pymmcore_gui/widgets/_mda_position_map.py
@@ -120,8 +120,10 @@ class MDAPositionMapWidget(QWidget):
             self._status.setText("No MDA positions to display.")
             return
 
+        footprint = footprints[0]
         self._status.setText(
-            f"{len(footprints)} position(s). FOV: {footprints[0].width_um:.1f} x {footprints[0].height_um:.1f} um"
+            f"{len(footprints)} position(s). "
+            f"FOV: {footprint.width_um:.1f} x {footprint.height_um:.1f} um"
         )
 
         for footprint in footprints:

--- a/tests/test_mda_position_map.py
+++ b/tests/test_mda_position_map.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import useq
+
+from pymmcore_gui import MicroManagerGUI
+from pymmcore_gui.actions import WidgetAction
+from pymmcore_gui.widgets._mda_position_map import (
+    MDAPositionMapWidget,
+    PositionFootprint,
+)
+
+
+def _position_map(qtbot, positions=()):
+    gui = MicroManagerGUI()
+    qtbot.addWidget(gui)
+    mda_widget = gui.get_widget(WidgetAction.MDA_WIDGET)
+    mda_widget.stage_positions.setValue(list(positions))
+    widget = MDAPositionMapWidget(mda_widget=mda_widget, mmcore=gui._mmc)
+    qtbot.addWidget(widget)
+    return gui, widget, mda_widget
+
+
+def test_position_map_starts_empty(qtbot) -> None:
+    _gui, widget, _mda_widget = _position_map(qtbot)
+
+    assert widget._collect_footprints() == []
+    assert widget._position_items == {}
+    assert widget._view._rect_to_row == {}
+    assert widget._status.text() == "No MDA positions to display."
+
+
+def test_position_map_collects_named_footprints(qtbot, monkeypatch) -> None:
+    _gui, widget, mda_widget = _position_map(qtbot)
+    monkeypatch.setattr(widget._mmc, "getImageWidth", lambda: 100)
+    monkeypatch.setattr(widget._mmc, "getImageHeight", lambda: 50)
+    monkeypatch.setattr(widget._mmc, "getPixelSizeUm", lambda: 0.5)
+
+    mda_widget.stage_positions.setValue(
+        [
+            useq.Position(x=10.0, y=20.0, name="Inlet"),
+            useq.Position(x=None, y=30.0, name="Skipped"),
+            useq.Position(x=40.0, y=50.0),
+        ]
+    )
+    widget.refresh()
+
+    assert widget._collect_footprints() == [
+        PositionFootprint(
+            row=0,
+            label="Inlet",
+            x_um=10.0,
+            y_um=20.0,
+            width_um=50.0,
+            height_um=25.0,
+        ),
+        PositionFootprint(
+            row=1,
+            label="Skipped",
+            x_um=0.0,
+            y_um=30.0,
+            width_um=50.0,
+            height_um=25.0,
+        ),
+        PositionFootprint(
+            row=2,
+            label="P3",
+            x_um=40.0,
+            y_um=50.0,
+            width_um=50.0,
+            height_um=25.0,
+        ),
+    ]
+    assert set(widget._position_items) == {0, 1, 2}
+    assert "3 position(s). FOV: 50.0 x 25.0 um" == widget._status.text()
+
+
+def test_position_map_selects_table_row_from_rect(qtbot) -> None:
+    _gui, widget, mda_widget = _position_map(qtbot)
+    mda_widget.stage_positions.setValue(
+        [
+            useq.Position(x=10.0, y=20.0, name="Inlet"),
+            useq.Position(x=40.0, y=50.0, name="Trap"),
+        ]
+    )
+    widget.refresh()
+
+    widget._select_row(1)
+
+    table = mda_widget.stage_positions.table()
+    assert table.currentRow() == 1
+    assert widget._selected_rows() == {1}
+    rect_item, label_item = widget._position_items[1]
+    assert rect_item.pen().width() == 3
+    assert label_item.brush().color().name().lower() == "#7c2d12"


### PR DESCRIPTION
## Summary

Draft feature PR for discussion. This adds an experimental MDA Position Map widget that gives a simple XY overview of positions defined in the MDA widget.

It includes:

- a design note describing the intended workflow
- a Qt graphics-view based overview of MDA position footprints
- table selection synchronization between the map and the MDA position table

## Background

This came from the same TiEclipse workflow as the Stage Explorer overlay work: when many positions are defined in the MDA, it is useful to see their spatial arrangement before acquisition. I do not have screenshots saved, so this is documented from commit history and code behavior.

## Notes for reviewers

This may overlap with or be superseded by the Stage Explorer overlay approach. I am opening it as a draft to decide whether a separate lightweight map widget is useful, or whether the feature should be folded into a single Stage Explorer workflow.

## Validation

- python -m ruff check MDA_POSITION_MAP_DESIGN.md src/pymmcore_gui/actions/widget_actions.py src/pymmcore_gui/widgets/_mda_position_map.py
- python -m compileall -q src/pymmcore_gui/widgets/_mda_position_map.py src/pymmcore_gui/actions/widget_actions.py